### PR TITLE
Fix templated-string regex using prefix as suffix in JSON mode

### DIFF
--- a/src/generate_json/generate.ts
+++ b/src/generate_json/generate.ts
@@ -42,7 +42,7 @@ export default class GenerateTranslationJSON {
 
         this.templatedStringRegex = getTemplatedStringRegex(
             options.templatedStringPrefix as string,
-            options.templatedStringPrefix as string,
+            options.templatedStringSuffix as string,
         );
     }
 


### PR DESCRIPTION
The GenerateTranslationJSON constructor passed templatedStringPrefix as both the prefix and suffix argument to getTemplatedStringRegex, so any non-default {{...}} delimiters (e.g. -p '${' -s '}') caused variable-preservation checks to silently skip real templated strings.