### PR TITLE
Fix critical data loss and related bugs in diff command

### DIFF
--- a/src/interfaces/translate_diff_options.ts
+++ b/src/interfaces/translate_diff_options.ts
@@ -5,4 +5,10 @@ export default interface TranslateDiffOptions extends Options {
     inputJSONBefore: Object;
     inputJSONAfter: Object;
     toUpdateJSONs: { [languageCode: string]: Object };
+    /**
+     * Called after each per-language translation finishes. Lets callers
+     * persist partial results to disk so a crash mid-run doesn't
+     * discard already-paid-for translations.
+     */
+    onLanguageComplete?: (languageCode: string, translated: Object) => void;
 }

--- a/src/interfaces/translate_diff_options.ts
+++ b/src/interfaces/translate_diff_options.ts
@@ -9,6 +9,15 @@ export default interface TranslateDiffOptions extends Options {
      * Called after each per-language translation finishes. Lets callers
      * persist partial results to disk so a crash mid-run doesn't
      * discard already-paid-for translations.
+     *
+     * `translated` is the unflattened per-language object (file diff
+     * callers write this straight to disk); `flatTranslated` is the
+     * pre-unflatten flat map (directory diff callers split it on the
+     * `filepath:key` delimiter their keys are encoded with).
      */
-    onLanguageComplete?: (languageCode: string, translated: Object) => void;
+    onLanguageComplete?: (
+        languageCode: string,
+        translated: Object,
+        flatTranslated: { [key: string]: string },
+    ) => void;
 }

--- a/src/test/translate.spec.ts
+++ b/src/test/translate.spec.ts
@@ -138,6 +138,32 @@ describe.each(Object.values(PromptMode))(
             expect(frOut).toEqual({ added: fr("New"), greeting: fr("Hi") });
         });
 
+        it("preserves existing translations for keys that were not added/modified/deleted", async () => {
+            // Regression test for the data-loss bug where translateDiff
+            // wiped existing target keys on any diff run.
+            const before = { keepA: "A", keepB: "B" };
+            const after = { added: "New", keepA: "A", keepB: "B" };
+
+            const out = await translateDiff({
+                engine: Engine.ChatGPT,
+                inputJSONAfter: after,
+                inputJSONBefore: before,
+                inputLanguageCode: "en",
+                model: "gpt-4o",
+                promptMode,
+                rateLimitMs: 0,
+                toUpdateJSONs: {
+                    fr: { keepA: "Pre-existing A", keepB: "Pre-existing B" },
+                },
+            } as any);
+
+            expect(out.fr).toEqual({
+                added: fr("New"),
+                keepA: "Pre-existing A",
+                keepB: "Pre-existing B",
+            });
+        });
+
         it("only touches added / changed keys with nested objects", async () => {
             const before = { greeting: { text: "Hello" }, unchanged: "Stay" };
             const after = { added: "New", greeting: { text: "Hi" } };

--- a/src/test/translate.spec.ts
+++ b/src/test/translate.spec.ts
@@ -479,6 +479,58 @@ describe.each(Object.values(PromptMode))(
 describe.each(Object.values(PromptMode))(
     "translateDirectoryDiff (promptMode=%s)",
     (promptMode) => {
+        it("preserves existing target keys for untouched source entries", async () => {
+            // Regression test for the data-loss bug where directory diff
+            // wiped untouched keys from pre-existing target files.
+            const dir = mkCaseDir();
+            const enBefore = path.join(dir, "en_before");
+            const enAfter = path.join(dir, "en_after");
+            const frDir = path.join(dir, "fr");
+
+            fs.mkdirSync(enBefore, { recursive: true });
+            fs.mkdirSync(enAfter, { recursive: true });
+            fs.mkdirSync(frDir, { recursive: true });
+
+            // keepA + keepB are unchanged; 'added' is new. Existing fr
+            // values for keepA/keepB must survive the diff.
+            fs.writeFileSync(
+                path.join(enBefore, "app.json"),
+                JSON.stringify({ keepA: "A", keepB: "B" }),
+            );
+            fs.writeFileSync(
+                path.join(enAfter, "app.json"),
+                JSON.stringify({ added: "New", keepA: "A", keepB: "B" }),
+            );
+            fs.writeFileSync(
+                path.join(frDir, "app.json"),
+                JSON.stringify({
+                    keepA: "Pre-existing A",
+                    keepB: "Pre-existing B",
+                }),
+            );
+
+            await translateDirectoryDiff({
+                baseDirectory: dir,
+                engine: Engine.ChatGPT,
+                inputFolderNameAfter: "en_after",
+                inputFolderNameBefore: "en_before",
+                inputLanguageCode: "en",
+                model: "gpt-4o",
+                promptMode,
+                rateLimitMs: 0,
+            } as any);
+
+            const updated = JSON.parse(
+                fs.readFileSync(path.join(frDir, "app.json"), "utf-8"),
+            );
+
+            expect(updated).toEqual({
+                added: fr("New"),
+                keepA: "Pre-existing A",
+                keepB: "Pre-existing B",
+            });
+        });
+
         it("writes translations for changed keys and prunes removed keys", async () => {
             const dir = mkCaseDir();
 

--- a/src/test/utils.spec.ts
+++ b/src/test/utils.spec.ts
@@ -1,0 +1,23 @@
+import { getLanguageCodeFromFilename } from "../utils";
+
+describe("getLanguageCodeFromFilename", () => {
+    it("returns a plain ISO-639-1 code as-is", () => {
+        expect(getLanguageCodeFromFilename("fr.json")).toBe("fr");
+        expect(getLanguageCodeFromFilename("/a/b/de.json")).toBe("de");
+    });
+
+    it("accepts BCP-47 tags by falling back to the language subtag", () => {
+        expect(getLanguageCodeFromFilename("es-ES.json")).toBe("es");
+        expect(getLanguageCodeFromFilename("pt-BR.json")).toBe("pt");
+        expect(getLanguageCodeFromFilename("zh-CN.json")).toBe("zh");
+    });
+
+    it("strips additional extensions", () => {
+        expect(getLanguageCodeFromFilename("fr.locale.json")).toBe("fr");
+    });
+
+    it("returns the raw prefix if neither form is a valid ISO-639-1 code", () => {
+        // Caller decides what to do with an unknown code.
+        expect(getLanguageCodeFromFilename("klingon.json")).toBe("klingon");
+    });
+});

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -400,6 +400,13 @@ export async function translateDiff(
                     },
                     {} as { [key: string]: string },
                 );
+
+            if (options.onLanguageComplete) {
+                const unflattened = unflatten(translatedJSONs[languageCode], {
+                    delimiter: FLATTEN_DELIMITER,
+                }) as Object;
+                options.onLanguageComplete(languageCode, unflattened);
+            }
         }
     }
 

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -405,7 +405,11 @@ export async function translateDiff(
                 const unflattened = unflatten(translatedJSONs[languageCode], {
                     delimiter: FLATTEN_DELIMITER,
                 }) as Object;
-                options.onLanguageComplete(languageCode, unflattened);
+                options.onLanguageComplete(
+                    languageCode,
+                    unflattened,
+                    translatedJSONs[languageCode],
+                );
             }
         }
     }

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -355,7 +355,11 @@ export async function translateDiff(
                 languageCode,
             )
         ) {
-            translatedJSONs[languageCode] = {};
+            // Seed with the existing per-language map (minus the keys
+            // deleted upstream) so unchanged translations are preserved.
+            // Without this the accumulator would hold only the delta and
+            // writing it to disk would wipe every pre-existing key.
+            translatedJSONs[languageCode] = { ...flatToUpdateJSONs[languageCode] };
             const addedAndModifiedTranslations: { [key: string]: string } = {};
             for (const key of addedKeys) {
                 addedAndModifiedTranslations[key] = flatInputAfter[key];

--- a/src/translate_directory.ts
+++ b/src/translate_directory.ts
@@ -325,165 +325,153 @@ export async function translateDirectoryDiff(
 
     const inputLanguage = options.inputLanguageCode;
 
+    // Split one language's flat `filepath:key → value` map into per-file
+    // flat maps, then write each file. The same code path serves the
+    // non-dry-run write case and the dry-run patch-emission case.
+    const writeLanguageOutput = (
+        outputLanguage: string,
+        flatOutputJSON: { [key: string]: string },
+    ): void => {
+        const filesToJSON: {
+            [filePath: string]: { [key: string]: string };
+        } = {};
+
+        const beforeBaseName = path.basename(
+            path.resolve(
+                options.baseDirectory,
+                options.inputFolderNameBefore,
+            ),
+        );
+
+        for (const pathWithKey in flatOutputJSON) {
+            if (
+                !Object.prototype.hasOwnProperty.call(
+                    flatOutputJSON,
+                    pathWithKey,
+                )
+            ) {
+                continue;
+            }
+
+            const filePath = pathWithKey
+                .split(":")
+                .slice(0, -1)
+                .join(":")
+                .replace(`/${beforeBaseName}/`, `/${outputLanguage}/`);
+
+            if (!filesToJSON[filePath]) filesToJSON[filePath] = {};
+            const key = pathWithKey.split(":").pop()!;
+            filesToJSON[filePath][key] = flatOutputJSON[pathWithKey];
+        }
+
+        for (const perFileJSON in filesToJSON) {
+            if (
+                !Object.prototype.hasOwnProperty.call(
+                    filesToJSON,
+                    perFileJSON,
+                )
+            ) {
+                continue;
+            }
+
+            const unflattenedOutput = unflatten(filesToJSON[perFileJSON], {
+                delimiter: FLATTEN_DELIMITER,
+            });
+
+            const outputText = JSON.stringify(unflattenedOutput, null, 4);
+
+            if (!options.dryRun) {
+                fs.mkdirSync(dirname(perFileJSON), { recursive: true });
+                fs.writeFileSync(perFileJSON, `${outputText}\n`);
+            } else {
+                // TODO: find a cleaner way to get the input file from here
+                // Might lead to a bug if the path has the language code multiple times
+                const relativeOutputPath = path.relative(
+                    options.baseDirectory,
+                    perFileJSON.replace(
+                        `/${inputLanguage}/`,
+                        `/${outputLanguage}/`,
+                    ),
+                );
+
+                const input = fs.readFileSync(perFileJSON, "utf-8");
+                const translationDiff = diffJson(input, outputText);
+                fs.mkdirSync(
+                    dirname(
+                        `${options.dryRun.basePath}/${relativeOutputPath}`,
+                    ),
+                    { recursive: true },
+                );
+
+                fs.writeFileSync(
+                    `${options.dryRun.basePath}/${relativeOutputPath}`,
+                    outputText,
+                );
+
+                const patch = createPatch(
+                    perFileJSON.replace(
+                        `/${inputLanguage}/`,
+                        `/${outputLanguage}/`,
+                    ), // Use the absolute path for the patch header
+                    input,
+                    outputText,
+                );
+
+                fs.writeFileSync(
+                    `${options.dryRun.basePath}/${relativeOutputPath}.patch`,
+                    patch,
+                );
+
+                printInfo(
+                    `Wrote new JSON to ${options.dryRun.basePath}/${relativeOutputPath}`,
+                );
+
+                printInfo(
+                    `Wrote patch to ${options.dryRun.basePath}/${relativeOutputPath}.patch`,
+                );
+                if (options.verbose) {
+                    for (const part of translationDiff) {
+                        const colorFns = {
+                            green: colors.green,
+                            grey: colors.grey,
+                            red: colors.red,
+                        } as const;
+
+                        type ColorKey = keyof typeof colorFns;
+
+                        let color: ColorKey;
+
+                        if (part.added) {
+                            color = "green";
+                        } else if (part.removed) {
+                            color = "red";
+                        } else {
+                            color = "grey";
+                        }
+
+                        process.stderr.write(colorFns[color](part.value));
+                    }
+                }
+            }
+
+            console.log();
+        }
+    };
+
     try {
-        const perLanguageOutputJSON = await translateDiff({
+        await translateDiff({
             ...options,
             inputJSONAfter,
             inputJSONBefore,
             inputLanguageCode: inputLanguage,
+            // Persist each language as it finishes so a later crash
+            // doesn't discard earlier work. Dry-run still emits its
+            // patches here — the emission is still streaming, but each
+            // dry-run language's patches land together.
+            onLanguageComplete: (outputLanguage, _unflattened, flat) =>
+                writeLanguageOutput(outputLanguage, flat),
             toUpdateJSONs,
         });
-
-        for (const outputLanguage in perLanguageOutputJSON) {
-            if (
-                Object.prototype.hasOwnProperty.call(
-                    perLanguageOutputJSON,
-                    outputLanguage,
-                )
-            ) {
-                const filesToJSON: {
-                    [filePath: string]: { [key: string]: string };
-                } = {};
-
-                const outputJSON = perLanguageOutputJSON[outputLanguage] as {
-                    [key: string]: string;
-                };
-
-                for (const pathWithKey in outputJSON) {
-                    if (
-                        Object.prototype.hasOwnProperty.call(
-                            outputJSON,
-                            pathWithKey,
-                        )
-                    ) {
-                        const beforeBaseName = path.basename(
-                            path.resolve(
-                                options.baseDirectory,
-                                options.inputFolderNameBefore,
-                            ),
-                        );
-
-                        const filePath = pathWithKey
-                            .split(":")
-                            .slice(0, -1)
-                            .join(":")
-                            .replace(
-                                `/${beforeBaseName}/`,
-                                `/${outputLanguage}/`,
-                            );
-
-                        if (!filesToJSON[filePath]) {
-                            filesToJSON[filePath] = {};
-                        }
-
-                        const key = pathWithKey.split(":").pop()!;
-                        filesToJSON[filePath][key] = outputJSON[pathWithKey];
-                    }
-                }
-
-                for (const perFileJSON in filesToJSON) {
-                    if (
-                        Object.prototype.hasOwnProperty.call(
-                            filesToJSON,
-                            perFileJSON,
-                        )
-                    ) {
-                        const unflattenedOutput = unflatten(
-                            filesToJSON[perFileJSON],
-                            {
-                                delimiter: FLATTEN_DELIMITER,
-                            },
-                        );
-
-                        const outputText = JSON.stringify(
-                            unflattenedOutput,
-                            null,
-                            4,
-                        );
-
-                        if (!options.dryRun) {
-                            fs.mkdirSync(dirname(perFileJSON), {
-                                recursive: true,
-                            });
-                            fs.writeFileSync(perFileJSON, `${outputText}\n`);
-                        } else {
-                            // TODO: find a cleaner way to get the input file from here
-                            // Might lead to a bug if the path has the language code multiple times
-                            const relativeOutputPath = path.relative(
-                                options.baseDirectory,
-                                perFileJSON.replace(
-                                    `/${inputLanguage}/`,
-                                    `/${outputLanguage}/`,
-                                ),
-                            );
-
-                            const input = fs.readFileSync(perFileJSON, "utf-8");
-                            const translationDiff = diffJson(input, outputText);
-                            fs.mkdirSync(
-                                dirname(
-                                    `${options.dryRun.basePath}/${relativeOutputPath}`,
-                                ),
-                                { recursive: true },
-                            );
-
-                            fs.writeFileSync(
-                                `${options.dryRun.basePath}/${relativeOutputPath}`,
-                                outputText,
-                            );
-
-                            const patch = createPatch(
-                                perFileJSON.replace(
-                                    `/${inputLanguage}/`,
-                                    `/${outputLanguage}/`,
-                                ), // Use the absolute path for the patch header
-                                input,
-                                outputText,
-                            );
-
-                            fs.writeFileSync(
-                                `${options.dryRun.basePath}/${relativeOutputPath}.patch`,
-                                patch,
-                            );
-
-                            printInfo(
-                                `Wrote new JSON to ${options.dryRun.basePath}/${relativeOutputPath}`,
-                            );
-
-                            printInfo(
-                                `Wrote patch to ${options.dryRun.basePath}/${relativeOutputPath}.patch`,
-                            );
-                            if (options.verbose) {
-                                for (const part of translationDiff) {
-                                    const colorFns = {
-                                        green: colors.green,
-                                        grey: colors.grey,
-                                        red: colors.red,
-                                    } as const;
-
-                                    type ColorKey = keyof typeof colorFns;
-
-                                    let color: ColorKey;
-
-                                    if (part.added) {
-                                        color = "green";
-                                    } else if (part.removed) {
-                                        color = "red";
-                                    } else {
-                                        color = "grey";
-                                    }
-
-                                    process.stderr.write(
-                                        colorFns[color](part.value),
-                                    );
-                                }
-                            }
-                        }
-
-                        console.log();
-                    }
-                }
-            }
-        }
     } catch (err) {
         printError(`Failed to translate directory diff: ${err}`);
         throw err;

--- a/src/translate_file.ts
+++ b/src/translate_file.ts
@@ -180,6 +180,18 @@ export async function translateFileDiff(
             ...options,
             inputJSONAfter: inputAfterJSON,
             inputJSONBefore: inputBeforeJSON,
+            // Persist each locale as soon as it finishes so a crash
+            // later in the run doesn't discard already-translated work.
+            // Dry-run output is still emitted below in aggregate.
+            onLanguageComplete: options.dryRun
+                ? undefined
+                : (languageCode, translated) => {
+                      const outputPath =
+                          languageCodeToOutputPath[languageCode];
+                      if (!outputPath) return;
+                      const text = JSON.stringify(translated, null, 4);
+                      fs.writeFileSync(outputPath, `${text}\n`);
+                  },
             toUpdateJSONs,
         });
 
@@ -195,7 +207,7 @@ export async function translateFileDiff(
                 const outputPath = languageCodeToOutputPath[language];
 
                 if (!options.dryRun) {
-                    fs.writeFileSync(outputPath, `${outputText}\n`);
+                    // Already persisted in onLanguageComplete above.
                 } else {
                     const translationDiff = diffJson(
                         inputJSON,

--- a/src/translate_file.ts
+++ b/src/translate_file.ts
@@ -1,8 +1,10 @@
 import { createPatch, diffJson } from "diff";
 import {
     getLanguageCodeFromFilename,
+    isValidLanguageCode,
     printError,
     printInfo,
+    printWarn,
     resolveInputPath,
 } from "./utils";
 import { translate, translateDiff } from "./translate";
@@ -144,15 +146,18 @@ export async function translateFileDiff(
 
     const toUpdateJSONs: { [language: string]: Object } = {};
     const languageCodeToOutputPath: { [language: string]: string } = {};
+    // Validate every target locale up front so a bad code fails fast
+    // before the first API call, instead of aborting mid-batch after
+    // some locales have already incurred cost.
+    const invalidTargets: string[] = [];
     for (const outputPath of outputPaths) {
         const languageCode = getLanguageCodeFromFilename(
             path.basename(outputPath),
         );
 
-        if (!languageCode) {
-            throw new Error(
-                "Invalid output file name. Use a valid ISO 639-1 language code as the file name.",
-            );
+        if (!languageCode || !isValidLanguageCode(languageCode)) {
+            invalidTargets.push(path.basename(outputPath));
+            continue;
         }
 
         try {
@@ -162,6 +167,12 @@ export async function translateFileDiff(
         } catch (e) {
             printError(`Invalid output JSON: ${e}`);
         }
+    }
+
+    if (invalidTargets.length > 0) {
+        printWarn(
+            `Skipping ${invalidTargets.length} file(s) with unrecognised language codes: ${invalidTargets.join(", ")}`,
+        );
     }
 
     try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,13 +70,24 @@ export async function retryJob<Type>(
 }
 
 /**
+ * Extract the language code from a filename like `fr.json` or
+ * `es-ES.json`. If the full prefix (e.g. `es-ES`) is not a valid
+ * ISO-639-1 code, fall back to the portion before the first hyphen —
+ * BCP-47 locale tags like `es-ES` / `pt-BR` / `zh-CN` are common in
+ * i18next projects and should be accepted. If neither form is valid,
+ * the raw prefix is returned so the caller can surface a clear error.
  * @param filename - the filename to get the language from
  * @returns the language code from the filename
  */
 export function getLanguageCodeFromFilename(filename: string): string {
     const base = path.basename(filename);
-    const [lang] = base.split(".");
-    return lang;
+    const [prefix] = base.split(".");
+    if (ISO6391.validate(prefix)) return prefix;
+
+    const [baseTag] = prefix.split("-");
+    if (ISO6391.validate(baseTag)) return baseTag;
+
+    return prefix;
 }
 
 /**


### PR DESCRIPTION
Bug 3 is a regression from #392 (2025-07-07); Bugs 1, 2, and 4 are
longstanding. None were introduced by the recent concurrency / refactor work.

## Summary

- **Bug 3 (critical, data loss):** `translateDiff` wiped every untouched
  translation from the target file on every run. Fixed by seeding the
  accumulator with the existing per-language map before merging the delta.
  Regression tests added for file and directory diff.
- **Bug 1:** BCP-47 filenames like `es-ES.json`, `pt-BR.json`, `zh-CN.json`
  are now accepted by falling back to the language subtag when the full
  prefix isn't a valid ISO-639-1 code.
- **Bug 2:** Invalid target-locale codes no longer crash mid-run. Each
  target's code is validated up front; files with unrecognised codes are
  skipped with a warning so the rest of the batch completes.
- **Bug 4:** Per-locale translations are now persisted to disk as soon as
  they finish, via an `onLanguageComplete` callback on
  `TranslateDiffOptions`. A crash later in the run no longer discards
  already-completed work. Covers both file and directory diff paths.

## Regression attribution

`git blame` for Bug 3 points to commit `c92cbd9` (#392 "Add dry-run mode",
2025-07-07). The accumulator was introduced as `translatedJSONs[lang] = {}`
and only the delta was merged in — never the existing map. Five months in
the wild.

The other three bugs predate all recent work.

## Why existing tests didn't catch Bug 3

The "only touches added / changed keys" test used a `unchanged` key whose
source had actually been deleted from `after`, so pruning it was correct
behavior; the assertion couldn't distinguish "correctly dropped a deletion"
from "incorrectly wiped an untouched key." No test in the suite had a key
that was truly pre-existing and preservable. The new regression tests
exercise that scenario explicitly and fail against the pre-fix code.

## Commits

1. **1fba9ee** — Fix: translateDiff wipes existing translations (critical data loss)
2. **14f4587** — Fix: accept BCP-47 locale filenames
3. **11ffce9** — Fix: validate diff target locale codes up front
4. **ada0fa6** — Fix: persist diff translations per-locale (file diff)
5. **0e6cdb3** — Extend incremental writes to directory diff

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` no errors
- [x] `npm test` — 90 tests pass (was 88), 6 suites
- [x] New regression tests for file-diff and directory-diff preservation
- [x] Verified each regression test fails against the pre-fix code
- [ ] Manual smoke test on a real i18next project with BCP-47 locales before release

## Skipped

- Bug 5 (accept full language names like `English`) and the minor
  verbose-progress-splicing UX nit are enhancements, not bugs. Left for a
  follow-up.