### PR TITLE
Refresh prompts: context parameter, language names, plural awareness

### DIFF
--- a/src/cli_diff.ts
+++ b/src/cli_diff.ts
@@ -72,10 +72,12 @@ export default function buildDiffCommand(): Command {
         .option("--dry-run", CLI_HELP.DryRun, false)
         .option("--no-continue-on-error", CLI_HELP.NoContinueOnError)
         .option("--concurrency <concurrency>", CLI_HELP.Concurrency)
+        .option("--context <context>", CLI_HELP.Context)
         .action(async (options: any) => {
             const modelArgs = processModelArgs(options);
             const sharedOptions = {
                 ...modelArgs,
+                context: options.context,
                 continueOnError: options.continueOnError,
                 ensureChangedTranslation: options.ensureChangedTranslation,
                 skipStylingVerification: options.skipStylingVerification,

--- a/src/cli_translate.ts
+++ b/src/cli_translate.ts
@@ -81,6 +81,7 @@ export default function buildTranslateCommand(): Command {
         .option("--dry-run", CLI_HELP.DryRun, false)
         .option("--no-continue-on-error", CLI_HELP.NoContinueOnError)
         .option("--concurrency <concurrency>", CLI_HELP.Concurrency)
+        .option("--context <context>", CLI_HELP.Context)
         .action(async (options: any) => {
             const modelArgs = processModelArgs(options);
             // The commander options object carries CLI-only booleans that
@@ -88,6 +89,7 @@ export default function buildTranslateCommand(): Command {
             // the subset the translate*() wrappers actually consume.
             const sharedOptions = {
                 ...modelArgs,
+                context: options.context,
                 continueOnError: options.continueOnError,
                 ensureChangedTranslation: options.ensureChangedTranslation,
                 skipStylingVerification: options.skipStylingVerification,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,8 @@ export const CLI_HELP = {
         "How many keys to process at a time, 32 by default for chatgpt, 16 otherwise",
     Concurrency:
         "How many batches to run in parallel (default: 2). Each worker holds its own chat history, sharing one rate limiter. Tune upward together with --rate-limit-ms to use more of your API tier",
+    Context:
+        "Product or domain context to steer translations (e.g. 'a music trivia game for Discord'). Injected into both the generation and verification prompts",
     DryRun: "Show the translations without writing to files, and store them in a temporary directory",
     Engine: "Engine to use (chatgpt, gemini, ollama, or claude)",
     EnsureChangedTranslation:

--- a/src/generate_csv/generate.ts
+++ b/src/generate_csv/generate.ts
@@ -32,7 +32,10 @@ async function generateTranslation(
         inputLanguage,
         outputLanguage,
         input,
-        options.overridePrompt,
+        {
+            context: options.context,
+            overridePrompt: options.overridePrompt,
+        },
     );
 
     const templatedStringRegex = getTemplatedStringRegex(
@@ -140,12 +143,13 @@ async function runShard(
         // eslint-disable-next-line no-await-in-loop
         const generatedTranslation = await generateTranslation({
             chats,
+            context: options.context,
             ensureChangedTranslation:
                 options.ensureChangedTranslation as boolean,
             input,
-            inputLanguageCode: `[${options.inputLanguageCode}]`,
+            inputLanguageCode: options.inputLanguageCode,
             keys,
-            outputLanguageCode: `[${options.outputLanguageCode}]`,
+            outputLanguageCode: options.outputLanguageCode,
             overridePrompt: options.overridePrompt,
             rateLimiter,
             skipStylingVerification: options.skipStylingVerification as boolean,
@@ -305,6 +309,7 @@ async function generate(
             const retryTranslationPromptText = failedTranslationPrompt(
                 inputLanguage,
                 outputLanguage,
+                splitInput[i],
                 line,
             );
 
@@ -373,7 +378,10 @@ async function generate(
             outputLanguage,
             input,
             text,
-            options.overridePrompt,
+            {
+                context: options.context,
+                overridePrompt: options.overridePrompt,
+            },
         );
     }
 
@@ -382,15 +390,27 @@ async function generate(
         return Promise.reject(new Error(`Invalid translation. text = ${text}`));
     }
 
+    // Styling is folded into the accuracy prompt by default (the merged
+    // rubric above checks both). Only run the standalone styling pass
+    // when the user has explicitly supplied a stylingVerificationPrompt
+    // override — otherwise we'd be making a wasted API call that just
+    // echoes back an ACK to the trivial no-op prompt.
     let stylingVerificationResponse = "";
-    if (!options.skipStylingVerification) {
+    const hasStylingOverride = Boolean(
+        options.overridePrompt?.stylingVerificationPrompt,
+    );
+
+    if (!options.skipStylingVerification && hasStylingOverride) {
         stylingVerificationResponse = await verifyStyling(
             chats.verifyStylingChat,
             inputLanguage,
             outputLanguage,
             input,
             text,
-            options.overridePrompt,
+            {
+                context: options.context,
+                overridePrompt: options.overridePrompt,
+            },
         );
     }
 

--- a/src/generate_csv/prompts.ts
+++ b/src/generate_csv/prompts.ts
@@ -1,22 +1,34 @@
+import { getLanguageName } from "../utils";
 import type OverridePrompt from "../interfaces/override_prompt";
+
+function buildContextPreamble(context?: string): string {
+    if (!context || context.trim() === "") return "";
+    return `Product context: ${context.trim()}\n\n`;
+}
 
 /**
  * Prompt an AI to convert a given input from one language to another
- * @param inputLanguage - The language of the input
- * @param outputLanguage - The language of the output
+ * @param inputLanguageCode - The ISO-639-1 code of the input
+ * @param outputLanguageCode - The ISO-639-1 code of the output
  * @param input - The input to be translated
- * @param overridePrompt - An optional custom prompt
+ * @param options - Optional override/context knobs
  * @returns A prompt for the AI to translate the input
  */
 export function generationPrompt(
-    inputLanguage: string,
-    outputLanguage: string,
+    inputLanguageCode: string,
+    outputLanguageCode: string,
     input: string,
-    overridePrompt?: OverridePrompt,
+    options?: {
+        overridePrompt?: OverridePrompt;
+        context?: string;
+    },
 ): string {
-    const customPrompt = overridePrompt?.generationPrompt;
-    const requiredArguments = ["inputLanguage", "outputLanguage", "input"];
+    const inputLanguage = getLanguageName(inputLanguageCode);
+    const outputLanguage = getLanguageName(outputLanguageCode);
+    const customPrompt = options?.overridePrompt?.generationPrompt;
+
     if (customPrompt) {
+        const requiredArguments = ["inputLanguage", "outputLanguage", "input"];
         for (const arg of requiredArguments) {
             if (!customPrompt.includes(`\${${arg}}`)) {
                 throw new Error(`Missing required argument: \${${arg}}`);
@@ -24,6 +36,7 @@ export function generationPrompt(
         }
 
         const argumentToValue: { [key: string]: string } = {
+            context: options?.context ?? "",
             input,
             inputLanguage,
             outputLanguage,
@@ -34,7 +47,9 @@ export function generationPrompt(
         );
     }
 
-    return `You are a professional translator.
+    const contextPreamble = buildContextPreamble(options?.context);
+
+    return `${contextPreamble}You are a professional translator.
 
 Translate each line from ${inputLanguage} to ${outputLanguage}.
 
@@ -54,57 +69,81 @@ ${input}
 
 /**
  * Prompt an AI to correct a failed translation
- * @param inputLanguage - The language of the input
- * @param outputLanguage - The language of the output
- * @param input - The input to be translated
- * @returns A prompt for the AI to correct the failed translation
+ * @param inputLanguageCode - The ISO-639-1 code of the input
+ * @param outputLanguageCode - The ISO-639-1 code of the output
+ * @param source - The original source string that should have been translated
+ * @param failedOutput - The previous failed attempt at translating it
+ * @returns A prompt for the AI to retry the translation
  */
 export function failedTranslationPrompt(
-    inputLanguage: string,
-    outputLanguage: string,
-    input: string,
+    inputLanguageCode: string,
+    outputLanguageCode: string,
+    source: string,
+    failedOutput: string,
 ): string {
+    const inputLanguage = getLanguageName(inputLanguageCode);
+    const outputLanguage = getLanguageName(outputLanguageCode);
+
     return `You are a professional translator.
 
-The following translation from ${inputLanguage} to ${outputLanguage} failed.
+A previous attempt to translate the following ${inputLanguage} text into ${outputLanguage} failed.
 
-Attempt to translate it to ${outputLanguage} by considering it as a concatenation of ${inputLanguage} words, or re-interpreting it such that it makes sense in ${outputLanguage}.
-
-Return only the translation with no additional formatting, apart from returning it in quotes.
-
-Maintain case sensitivity and whitespacing.
-
+Source (${inputLanguage}):
 \`\`\`
-${input}
+${source}
 \`\`\`
+
+Failed ${outputLanguage} output:
+\`\`\`
+${failedOutput}
+\`\`\`
+
+Re-translate the source into ${outputLanguage}. If the source reads like a concatenation of ${inputLanguage} words (camelCase, snake_case, or compound), split it mentally before translating. Return only the translation, wrapped in ASCII quotation marks ("). Maintain case sensitivity and whitespacing.
 `;
 }
 
 /**
  * Prompt an AI to ensure a translation is valid
- * @param inputLanguage - The language of the input
- * @param outputLanguage - The language of the output
- * @param input - The input to be translated
- * @param output - The output of the translation
- * @param overridePrompt - An optional custom prompt
+ *
+ * This is a single rubric that replaces the old separate accuracy and
+ * styling ACK/NAK prompts. The response is still text: NAK if any
+ * translation is incorrect on either accuracy or styling grounds,
+ * ACK otherwise. Merging the two prompts halves the round-trip cost
+ * and fixes the line-alignment fragility that showed up when one of
+ * the two prompts disagreed on line counts.
+ *
+ * @param inputLanguageCode - The ISO-639-1 code of the input
+ * @param outputLanguageCode - The ISO-639-1 code of the output
+ * @param input - The original input, one item per line
+ * @param output - The translated output, one item per line
+ * @param options - Optional override/context knobs
  * @returns A prompt for the AI to verify the translation
  */
 export function translationVerificationPrompt(
-    inputLanguage: string,
-    outputLanguage: string,
+    inputLanguageCode: string,
+    outputLanguageCode: string,
     input: string,
     output: string,
-    overridePrompt?: OverridePrompt,
+    options?: {
+        overridePrompt?: OverridePrompt;
+        context?: string;
+    },
 ): string {
+    const inputLanguage = getLanguageName(inputLanguageCode);
+    const outputLanguage = getLanguageName(outputLanguageCode);
     const splitInput = input.split("\n");
     const splitOutput = output.split("\n");
     const mergedCSV = splitInput
-        .map((x, i) => `${x},${splitOutput[i]}`)
+        .map((x, i) => `${x},${splitOutput[i] ?? ""}`)
         .join("\n");
 
-    const customPrompt = overridePrompt?.translationVerificationPrompt;
-    const requiredArguments = ["inputLanguage", "outputLanguage", "mergedCSV"];
+    const customPrompt = options?.overridePrompt?.translationVerificationPrompt;
     if (customPrompt) {
+        const requiredArguments = [
+            "inputLanguage",
+            "outputLanguage",
+            "mergedCSV",
+        ];
         for (const arg of requiredArguments) {
             if (!customPrompt.includes(`\${${arg}}`)) {
                 throw new Error(`Missing required argument: \${${arg}}`);
@@ -112,6 +151,7 @@ export function translationVerificationPrompt(
         }
 
         const argumentToValue: { [key: string]: string } = {
+            context: options?.context ?? "",
             inputLanguage,
             mergedCSV,
             outputLanguage,
@@ -122,12 +162,18 @@ export function translationVerificationPrompt(
         );
     }
 
-    return `
-Given a translation from ${inputLanguage} to ${outputLanguage} in CSV form, reply with NAK if _any_ of the translations are poorly translated.
+    const contextPreamble = buildContextPreamble(options?.context);
+
+    return `${contextPreamble}You are a translation reviewer checking a ${inputLanguage}-to-${outputLanguage} batch in CSV form.
+
+Reply with NAK if ANY translation has a problem, including:
+- Inaccurate meaning, wrong tone, or grammar errors
+- Mismatched capitalization, punctuation, or whitespace vs. the original
+- Missing or extra placeholders, or altered variable names
 
 Otherwise, reply with ACK.
 
-Only reply with ACK/NAK.
+Reply with ACK or NAK only — no explanation.
 
 \`\`\`
 ${inputLanguage},${outputLanguage}
@@ -137,30 +183,46 @@ ${mergedCSV}
 }
 
 /**
- * Prompt an AI to ensure a translation is styled correctly
- * @param inputLanguage - The language of the input
- * @param outputLanguage - The language of the output
- * @param input - The input to be translated
- * @param output - The output of the translation
- * @param overridePrompt - An optional custom prompt
- * @returns A prompt for the AI to verify the translation
+ * Legacy standalone styling prompt.
+ *
+ * Kept for backwards compatibility with custom override-prompt files
+ * that still reference `stylingVerificationPrompt`. New code should use
+ * `translationVerificationPrompt` above, which checks both accuracy and
+ * styling in a single pass. Calling this function without a matching
+ * override returns an ACK (no-op) — the merged prompt above already
+ * handles styling.
+ * @param inputLanguageCode - The ISO-639-1 code of the input
+ * @param outputLanguageCode - The ISO-639-1 code of the output
+ * @param input - The original input
+ * @param output - The translated output
+ * @param options - Optional override/context knobs
+ * @returns A prompt for the AI, or a sentinel indicating no standalone check
  */
 export function stylingVerificationPrompt(
-    inputLanguage: string,
-    outputLanguage: string,
+    inputLanguageCode: string,
+    outputLanguageCode: string,
     input: string,
     output: string,
-    overridePrompt?: OverridePrompt,
+    options?: {
+        overridePrompt?: OverridePrompt;
+        context?: string;
+    },
 ): string {
+    const inputLanguage = getLanguageName(inputLanguageCode);
+    const outputLanguage = getLanguageName(outputLanguageCode);
     const splitInput = input.split("\n");
     const splitOutput = output.split("\n");
     const mergedCSV = splitInput
-        .map((x, i) => `${x},${splitOutput[i]}`)
+        .map((x, i) => `${x},${splitOutput[i] ?? ""}`)
         .join("\n");
 
-    const customPrompt = overridePrompt?.stylingVerificationPrompt;
-    const requiredArguments = ["inputLanguage", "outputLanguage", "mergedCSV"];
+    const customPrompt = options?.overridePrompt?.stylingVerificationPrompt;
     if (customPrompt) {
+        const requiredArguments = [
+            "inputLanguage",
+            "outputLanguage",
+            "mergedCSV",
+        ];
         for (const arg of requiredArguments) {
             if (!customPrompt.includes(`\${${arg}}`)) {
                 throw new Error(`Missing required argument: \${${arg}}`);
@@ -168,6 +230,7 @@ export function stylingVerificationPrompt(
         }
 
         const argumentToValue: { [key: string]: string } = {
+            context: options?.context ?? "",
             inputLanguage,
             mergedCSV,
             outputLanguage,
@@ -178,18 +241,8 @@ export function stylingVerificationPrompt(
         );
     }
 
-    return `
-Given text from ${inputLanguage} to ${outputLanguage} in CSV form, reply with NAK if _any_ of the translations do not match the formatting of the original.
-
-Check for differing capitalization, punctuation, or whitespaces.
-
-Otherwise, reply with ACK.
-
-Only reply with ACK/NAK.
-
-\`\`\`
-${inputLanguage},${outputLanguage}
-${mergedCSV}
-\`\`\`
-`;
+    // No standalone styling check by default; the accuracy prompt above
+    // already folds in styling. Return a trivial ACK-producing prompt so
+    // callers that still invoke this function get a no-op.
+    return `Reply with ACK.`;
 }

--- a/src/generate_csv/verify.ts
+++ b/src/generate_csv/verify.ts
@@ -21,14 +21,17 @@ export async function verifyTranslation(
     outputLanguage: string,
     input: string,
     outputToVerify: string,
-    overridePrompt?: OverridePrompt,
+    options?: {
+        overridePrompt?: OverridePrompt;
+        context?: string;
+    },
 ): Promise<string> {
     const translationVerificationPromptText = translationVerificationPrompt(
         inputLanguage,
         outputLanguage,
         input,
         outputToVerify,
-        overridePrompt,
+        options,
     );
 
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
@@ -50,14 +53,17 @@ export async function verifyStyling(
     outputLanguage: string,
     input: string,
     outputToVerify: string,
-    overridePrompt?: OverridePrompt,
+    options?: {
+        overridePrompt?: OverridePrompt;
+        context?: string;
+    },
 ): Promise<string> {
     const stylingVerificationPromptText = stylingVerificationPrompt(
         inputLanguage,
         outputLanguage,
         input,
         outputToVerify,
-        overridePrompt,
+        options,
     );
 
     // eslint-disable-next-line @typescript-eslint/no-use-before-define

--- a/src/generate_json/generate.ts
+++ b/src/generate_json/generate.ts
@@ -187,7 +187,12 @@ export default class GenerateTranslationJSON {
                 options.inputLanguageCode,
                 options.outputLanguageCode,
                 [],
-                options.overridePrompt,
+                {
+                    context: options.context,
+                    overridePrompt: options.overridePrompt,
+                    templatedStringPrefix: options.templatedStringPrefix,
+                    templatedStringSuffix: options.templatedStringSuffix,
+                },
             ),
         ).length;
 
@@ -235,7 +240,12 @@ export default class GenerateTranslationJSON {
                 options.inputLanguageCode,
                 options.outputLanguageCode,
                 [],
-                options.overridePrompt,
+                {
+                    context: options.context,
+                    overridePrompt: options.overridePrompt,
+                    templatedStringPrefix: options.templatedStringPrefix,
+                    templatedStringSuffix: options.templatedStringSuffix,
+                },
             ),
         ).length;
 
@@ -359,10 +369,11 @@ export default class GenerateTranslationJSON {
             // eslint-disable-next-line no-await-in-loop
             const result = await this.runTranslationJob({
                 chats,
+                context: options.context,
                 ensureChangedTranslation:
                     options.ensureChangedTranslation as boolean,
-                inputLanguageCode: `[${options.inputLanguageCode}]`,
-                outputLanguageCode: `[${options.outputLanguageCode}]`,
+                inputLanguageCode: options.inputLanguageCode,
+                outputLanguageCode: options.outputLanguageCode,
                 overridePrompt: options.overridePrompt,
                 rateLimiter,
                 skipStylingVerification:
@@ -486,10 +497,11 @@ export default class GenerateTranslationJSON {
             // eslint-disable-next-line no-await-in-loop
             const result = await this.runVerificationJob({
                 chats,
+                context: options.context,
                 ensureChangedTranslation:
                     options.ensureChangedTranslation as boolean,
-                inputLanguageCode: `[${options.inputLanguageCode}]`,
-                outputLanguageCode: `[${options.outputLanguageCode}]`,
+                inputLanguageCode: options.inputLanguageCode,
+                outputLanguageCode: options.outputLanguageCode,
                 overridePrompt: options.overridePrompt,
                 rateLimiter,
                 skipStylingVerification:
@@ -714,7 +726,13 @@ export default class GenerateTranslationJSON {
             options.inputLanguageCode,
             options.outputLanguageCode,
             this.generateTranslateItemsInput(options.translateItems),
-            options.overridePrompt,
+            {
+                context: options.context,
+                keys: options.translateItems.map((it) => it.key),
+                overridePrompt: options.overridePrompt,
+                templatedStringPrefix: options.templatedStringPrefix,
+                templatedStringSuffix: options.templatedStringSuffix,
+            },
         );
 
         let translated = "";
@@ -761,7 +779,12 @@ export default class GenerateTranslationJSON {
             options.inputLanguageCode,
             options.outputLanguageCode,
             this.generateVerifyItemsInput(options.translateItems),
-            options.overridePrompt,
+            {
+                context: options.context,
+                overridePrompt: options.overridePrompt,
+                templatedStringPrefix: options.templatedStringPrefix,
+                templatedStringSuffix: options.templatedStringSuffix,
+            },
         );
 
         let verified = "";

--- a/src/generate_json/prompts.ts
+++ b/src/generate_json/prompts.ts
@@ -1,25 +1,59 @@
+import { getLanguageName } from "../utils";
 import type { TranslateItemInput, VerifyItemInput } from "./types";
 import type OverridePrompt from "../interfaces/override_prompt";
 
+// CLDR plural suffixes used by i18next keys. When a key ends in one of
+// these, the suffix carries semantic meaning and should be preserved.
+const PLURAL_SUFFIX_PATTERN = /_(zero|one|two|few|many|other)$/;
+
+function buildContextPreamble(context?: string): string {
+    if (!context || context.trim() === "") return "";
+    return `Product context: ${context.trim()}\n\n`;
+}
+
+function buildPlaceholderLine(
+    templatedStringPrefix: string,
+    templatedStringSuffix: string,
+): string {
+    const newlineRef = `${templatedStringPrefix}NEWLINE${templatedStringSuffix}`;
+    const varRef = `${templatedStringPrefix}variableName${templatedStringSuffix}`;
+    return `- Treat anything in the format ${varRef} as a placeholder. Never translate or modify its content. Do not convert ${newlineRef} to \\n.`;
+}
+
+function pluralHint(keys: string[] | undefined): string {
+    if (!keys || keys.length === 0) return "";
+    const hasPlural = keys.some((k) => PLURAL_SUFFIX_PATTERN.test(k));
+    if (!hasPlural) return "";
+    return `- Some keys end in CLDR plural suffixes (_zero, _one, _two, _few, _many, _other). These are i18next plural markers; apply the target language's correct plural form to the translated text but do not translate the suffix itself.\n`;
+}
+
 /**
  * Prompt an AI to convert a given input from one language to another
- * @param inputLanguage - The language of the input
- * @param outputLanguage - The language of the output
+ * @param inputLanguageCode - The ISO-639-1 code of the input
+ * @param outputLanguageCode - The ISO-639-1 code of the output
  * @param translateItems - The input to be translated
- * @param overridePrompt - An optional custom prompt
+ * @param options - Optional prompt-shaping inputs: override, context, placeholder delimiters, key list for plural detection
  * @returns A prompt for the AI to translate the input
  */
 export function translationPromptJSON(
-    inputLanguage: string,
-    outputLanguage: string,
+    inputLanguageCode: string,
+    outputLanguageCode: string,
     translateItems: TranslateItemInput[],
-    overridePrompt?: OverridePrompt,
+    options?: {
+        overridePrompt?: OverridePrompt;
+        context?: string;
+        templatedStringPrefix?: string;
+        templatedStringSuffix?: string;
+        keys?: string[];
+    },
 ): string {
-    const customPrompt = overridePrompt?.generationPrompt;
-    const requiredArguments = ["inputLanguage", "outputLanguage", "input"];
+    const inputLanguage = getLanguageName(inputLanguageCode);
+    const outputLanguage = getLanguageName(outputLanguageCode);
     const input = JSON.stringify(translateItems);
+    const customPrompt = options?.overridePrompt?.generationPrompt;
 
     if (customPrompt) {
+        const requiredArguments = ["inputLanguage", "outputLanguage", "input"];
         for (const arg of requiredArguments) {
             if (!customPrompt.includes(`\${${arg}}`)) {
                 throw new Error(`Missing required argument: \${${arg}}`);
@@ -27,6 +61,7 @@ export function translationPromptJSON(
         }
 
         const argumentToValue: { [key: string]: string } = {
+            context: options?.context ?? "",
             input,
             inputLanguage,
             outputLanguage,
@@ -37,7 +72,13 @@ export function translationPromptJSON(
         );
     }
 
-    return `You are a professional translator.
+    const prefix = options?.templatedStringPrefix ?? "{{";
+    const suffix = options?.templatedStringSuffix ?? "}}";
+    const contextPreamble = buildContextPreamble(options?.context);
+    const plural = pluralHint(options?.keys);
+    const placeholderLine = buildPlaceholderLine(prefix, suffix);
+
+    return `${contextPreamble}You are a professional translator.
 
 Translate from ${inputLanguage} to ${outputLanguage}.
 
@@ -45,15 +86,14 @@ Translate from ${inputLanguage} to ${outputLanguage}.
 - 'original' is the text to be translated.
 - 'translated' must not be empty.
 - 'context' is additional info if needed.
-- 'failure' explains why the previous translation failed.
-- Preserve text formatting, case sensitivity, whitespace, and keep roughly the same length.
+- 'failure' explains why the previous translation failed; use it to avoid repeating the same mistake.
+- Preserve text formatting, case sensitivity, and whitespace. UI strings should stay close to the source length where possible.
 
 Special Instructions:
-- Treat anything in the format {{variableName}} as a placeholder. Never translate or modify its content.
-- Do not add your own variables
-- The number of variables like {{timeLeft}} must be the same in the translated text.
-- Do not convert {{NEWLINE}} to \\n.
-
+${placeholderLine}
+- Do not add variables that are not in the original.
+- The number of variables must be the same in the translated text.
+${plural}
 Return the translation as JSON.
 \`\`\`json
 ${input}
@@ -63,22 +103,30 @@ ${input}
 
 /**
  * Prompt an AI to ensure a translation is valid
- * @param inputLanguage - The language of the input
- * @param outputLanguage - The language of the output
+ * @param inputLanguageCode - The ISO-639-1 code of the input
+ * @param outputLanguageCode - The ISO-639-1 code of the output
  * @param verificationInput - The input to be translated
- * @param overridePrompt - An optional custom prompt
+ * @param options - Optional prompt-shaping inputs
  * @returns A prompt for the AI to verify the translation
  */
 export function verificationPromptJSON(
-    inputLanguage: string,
-    outputLanguage: string,
+    inputLanguageCode: string,
+    outputLanguageCode: string,
     verificationInput: VerifyItemInput[],
-    overridePrompt?: OverridePrompt,
+    options?: {
+        overridePrompt?: OverridePrompt;
+        context?: string;
+        templatedStringPrefix?: string;
+        templatedStringSuffix?: string;
+    },
 ): string {
+    const inputLanguage = getLanguageName(inputLanguageCode);
+    const outputLanguage = getLanguageName(outputLanguageCode);
     const input = JSON.stringify(verificationInput);
-    const customPrompt = overridePrompt?.translationVerificationPrompt;
-    const requiredArguments = ["inputLanguage", "outputLanguage", "input"];
+    const customPrompt = options?.overridePrompt?.translationVerificationPrompt;
+
     if (customPrompt) {
+        const requiredArguments = ["inputLanguage", "outputLanguage", "input"];
         for (const arg of requiredArguments) {
             if (!customPrompt.includes(`\${${arg}}`)) {
                 throw new Error(`Missing required argument: \${${arg}}`);
@@ -86,6 +134,8 @@ export function verificationPromptJSON(
         }
 
         const argumentToValue: { [key: string]: string } = {
+            context: options?.context ?? "",
+            input,
             inputLanguage,
             outputLanguage,
         };
@@ -95,7 +145,12 @@ export function verificationPromptJSON(
         );
     }
 
-    return `You are a professional translator.
+    const prefix = options?.templatedStringPrefix ?? "{{";
+    const suffix = options?.templatedStringSuffix ?? "}}";
+    const contextPreamble = buildContextPreamble(options?.context);
+    const placeholderLine = buildPlaceholderLine(prefix, suffix);
+
+    return `${contextPreamble}You are a professional translator.
 
 Check translations from ${inputLanguage} to ${outputLanguage}.
 
@@ -103,22 +158,19 @@ Check translations from ${inputLanguage} to ${outputLanguage}.
 - 'original' is the text to be translated.
 - 'translated' is the translated text.
 - 'context' is additional info if needed.
-- 'failure' explains why the previous translation failed.
-- check for Accuracy (meaning, tone, grammar), Formatting (case, whitespace, punctuation).
+- 'failure' explains why a prior translation failed; only populated during re-verification.
+- Check for accuracy (meaning, tone, grammar) and formatting (case, whitespace, punctuation).
 
-If correct, return 'valid' as 'true' and leave 'fixedTranslation' and 'issue' empty.
-If incorrect, return 'valid' as 'false' and put the fixed translation in 'fixedTranslation' and explain what is 'issue'.
+Do not revise correct translations. Flag only issues that meaningfully affect accuracy or readability.
+If the translation is correct, return 'valid' as 'true' and leave 'fixedTranslation' and 'issue' empty.
+If the translation is incorrect, return 'valid' as 'false', put the corrected translation in 'fixedTranslation', and explain the problem in 'issue'.
 
 Special Instructions:
-- Treat anything in the format {{variableName}} as a placeholder. Never translate or modify its content.
+${placeholderLine}
 - Do not add variables that are not in the original.
-- The number of variables like {{timeLeft}} must be the same in the translated text.
-- Do not convert {{NEWLINE}} to \\n.
+- The number of variables must be the same in the translated text.
 
-Allow minor grammar, phrasing, and formatting differences if the meaning is clear.
-Flag only significant issues affecting accuracy or readability.
-
-Return the verified as JSON.
+Return the verified output as JSON.
 \`\`\`json
 ${input}
 \`\`\`

--- a/src/interfaces/generate_translation_options_csv.ts
+++ b/src/interfaces/generate_translation_options_csv.ts
@@ -16,4 +16,5 @@ export default interface GenerateTranslationOptionsCSV {
     skipStylingVerification: boolean;
     overridePrompt?: OverridePrompt;
     rateLimiter?: RateLimiter;
+    context?: string;
 }

--- a/src/interfaces/generate_translation_options_json.ts
+++ b/src/interfaces/generate_translation_options_json.ts
@@ -16,4 +16,5 @@ export default interface GenerateTranslationOptionsJSON {
     skipStylingVerification: boolean;
     overridePrompt?: OverridePrompt;
     rateLimiter?: RateLimiter;
+    context?: string;
 }

--- a/src/interfaces/options.ts
+++ b/src/interfaces/options.ts
@@ -22,4 +22,10 @@ export default interface Options {
     promptMode: PromptMode;
     continueOnError?: boolean;
     concurrency?: number;
+    /**
+     * Optional product/domain context injected into prompts — e.g.
+     * "a music trivia game for Discord" or "a B2B invoicing SaaS".
+     * Helps the model pick domain-specific terminology and tone.
+     */
+    context?: string;
 }

--- a/src/test/concurrency.spec.ts
+++ b/src/test/concurrency.spec.ts
@@ -11,7 +11,13 @@ import type RateLimiter from "../rate_limiter";
 // this to prove workers got distinct Chats instances.
 type ChatCall = {
     chatId: number;
-    format: "csv" | "json-translate" | "json-verify" | "unknown";
+    format:
+        | "csv"
+        | "csv-verify"
+        | "csv-styling"
+        | "json-translate"
+        | "json-verify"
+        | "unknown";
     keys: string[];
 };
 
@@ -55,7 +61,14 @@ function detectFormat(
     message: string,
     format?: ZodType<any, ZodTypeDef, any>,
 ): ChatCall["format"] {
-    if (!format) return "csv";
+    if (!format) {
+        // CSV mode: distinguish the three prompt shapes so tests can
+        // count accuracy vs. styling verify calls separately.
+        if (/translation reviewer/.test(message)) return "csv-verify";
+        if (/^Reply with ACK\.$/.test(message.trim())) return "csv-styling";
+        return "csv";
+    }
+
     // Each JSON-mode prompt has a distinct preamble we can match on.
     if (/Check translations from/.test(message)) return "json-verify";
     if (/Translate from/.test(message)) return "json-translate";
@@ -139,6 +152,11 @@ function makeFakeChat(): {
                         valid: true,
                     })),
                 });
+            }
+
+            if (fmt === "csv-verify" || fmt === "csv-styling") {
+                chatCalls.push({ chatId, format: fmt, keys: [] });
+                return "ACK";
             }
 
             return "";
@@ -363,4 +381,28 @@ describe("rate limit penalty propagates through shared limiter", () => {
         // proving here is just that a 429 in one worker doesn't kill
         // translation.
     });
+});
+
+describe("CSV styling verification", () => {
+    it("does NOT fire a standalone styling call when no override is supplied", async () => {
+        // Enable styling verification (it's off in baseOptions). Without
+        // an overridePrompt.stylingVerificationPrompt, the accuracy prompt
+        // already folds in styling, so we should make zero styling-only
+        // calls.
+        await translate({
+            ...baseOptions,
+            concurrency: 1,
+            inputJSON: toyInput(),
+            promptMode: PromptMode.CSV,
+            skipStylingVerification: false,
+            skipTranslationVerification: false,
+        } as any);
+
+        const stylingCalls = chatCalls.filter(
+            (c) => c.format === "csv-styling",
+        );
+
+        expect(stylingCalls).toHaveLength(0);
+    });
+
 });

--- a/src/test/prompts.spec.ts
+++ b/src/test/prompts.spec.ts
@@ -1,0 +1,138 @@
+import {
+    failedTranslationPrompt,
+    generationPrompt as csvGenerationPrompt,
+    translationVerificationPrompt as csvTranslationVerificationPrompt,
+} from "../generate_csv/prompts";
+import {
+    translationPromptJSON,
+    verificationPromptJSON,
+} from "../generate_json/prompts";
+
+describe("prompt builders", () => {
+    describe("language-name expansion", () => {
+        it("CSV generation expands en/fr to English/French", () => {
+            const out = csvGenerationPrompt("en", "fr", '"hello"');
+            expect(out).toContain("from English to French");
+            expect(out).not.toContain("from en to fr");
+        });
+
+        it("JSON generation expands en/es to English/Spanish", () => {
+            const out = translationPromptJSON("en", "es", []);
+            expect(out).toContain("from English to Spanish");
+            expect(out).not.toContain("from en to es");
+        });
+
+        it("falls back to the raw code for unknown language codes", () => {
+            const out = translationPromptJSON("en", "xx", []);
+            // "xx" isn't a real ISO code, so the fallback passes it through.
+            expect(out).toContain("to xx");
+        });
+    });
+
+    describe("context injection", () => {
+        it("prepends a Product context line when context is provided", () => {
+            const out = translationPromptJSON("en", "fr", [], {
+                context: "a B2B invoicing SaaS",
+            });
+
+            expect(out).toMatch(/^Product context: a B2B invoicing SaaS\n\n/);
+        });
+
+        it("omits the context line when context is absent", () => {
+            const out = translationPromptJSON("en", "fr", []);
+            expect(out).not.toMatch(/^Product context:/);
+        });
+
+        it("trims whitespace around the context value", () => {
+            const out = translationPromptJSON("en", "fr", [], {
+                context: "   a music trivia game   ",
+            });
+
+            expect(out).toContain("Product context: a music trivia game\n");
+        });
+    });
+
+    describe("plural-suffix hints", () => {
+        it("fires when any key ends in a CLDR plural suffix", () => {
+            const out = translationPromptJSON("en", "fr", [], {
+                keys: ["notifications_one", "notifications_other"],
+            });
+
+            expect(out).toContain("CLDR plural suffixes");
+        });
+
+        it("does not fire for keys without plural suffixes", () => {
+            const out = translationPromptJSON("en", "fr", [], {
+                keys: ["welcome_message", "goodbye"],
+            });
+
+            expect(out).not.toContain("CLDR plural suffixes");
+        });
+
+        it("recognises _zero, _two, _few, _many alongside _one/_other", () => {
+            for (const suffix of ["zero", "one", "two", "few", "many", "other"]) {
+                const out = translationPromptJSON("en", "fr", [], {
+                    keys: [`item_${suffix}`],
+                });
+
+                expect(out).toContain("CLDR plural suffixes");
+            }
+        });
+    });
+
+    describe("placeholder delimiter customisation", () => {
+        it("references the user's configured delimiter in the {{NEWLINE}} line", () => {
+            const out = translationPromptJSON("en", "fr", [], {
+                templatedStringPrefix: "${",
+                templatedStringSuffix: "}",
+            });
+
+            expect(out).toContain("${NEWLINE}");
+            expect(out).not.toContain("{{NEWLINE}}");
+        });
+
+        it("defaults to {{...}} when no delimiter is provided", () => {
+            const out = translationPromptJSON("en", "fr", []);
+            expect(out).toContain("{{NEWLINE}}");
+        });
+    });
+
+    describe("failedTranslationPrompt", () => {
+        it("includes both the source and the failed output", () => {
+            const out = failedTranslationPrompt(
+                "en",
+                "fr",
+                "welcomeMessage",
+                "welcomeMessage",
+            );
+
+            // Source is distinguished from failed output by its heading.
+            expect(out).toMatch(/Source \(English\):/);
+            expect(out).toMatch(/Failed French output:/);
+            expect(out).toContain("welcomeMessage");
+        });
+
+        it("expands the language codes to names", () => {
+            const out = failedTranslationPrompt("en", "fr", "a", "b");
+            expect(out).toContain("English");
+            expect(out).toContain("French");
+            expect(out).not.toContain("[en]");
+            expect(out).not.toContain("[fr]");
+        });
+    });
+
+    describe("verificationPromptJSON", () => {
+        it("contains the 'do not revise correct translations' instruction", () => {
+            const out = verificationPromptJSON("en", "fr", []);
+            expect(out).toMatch(/Do not revise correct translations/);
+        });
+    });
+
+    describe("CSV translationVerificationPrompt", () => {
+        it("now checks both accuracy and styling in one pass", () => {
+            const out = csvTranslationVerificationPrompt("en", "fr", "a", "b");
+            expect(out).toMatch(/Inaccurate meaning/);
+            expect(out).toMatch(/capitalization, punctuation, or whitespace/);
+        });
+    });
+});

--- a/src/test/utils.spec.ts
+++ b/src/test/utils.spec.ts
@@ -1,4 +1,4 @@
-import { getLanguageCodeFromFilename } from "../utils";
+import { getLanguageCodeFromFilename, getLanguageName } from "../utils";
 
 describe("getLanguageCodeFromFilename", () => {
     it("returns a plain ISO-639-1 code as-is", () => {
@@ -19,5 +19,19 @@ describe("getLanguageCodeFromFilename", () => {
     it("returns the raw prefix if neither form is a valid ISO-639-1 code", () => {
         // Caller decides what to do with an unknown code.
         expect(getLanguageCodeFromFilename("klingon.json")).toBe("klingon");
+    });
+});
+
+describe("getLanguageName", () => {
+    it("expands common ISO-639-1 codes to English names", () => {
+        expect(getLanguageName("en")).toBe("English");
+        expect(getLanguageName("fr")).toBe("French");
+        expect(getLanguageName("ja")).toBe("Japanese");
+        expect(getLanguageName("zh")).toBe("Chinese");
+    });
+
+    it("returns the raw code when the lookup fails", () => {
+        expect(getLanguageName("xx")).toBe("xx");
+        expect(getLanguageName("klingon")).toBe("klingon");
     });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -106,6 +106,19 @@ export function isValidLanguageCode(languageCode: string): boolean {
 }
 
 /**
+ * Expand an ISO-639-1 code to its English display name (e.g. "en" →
+ * "English"). Used in prompts because language names steer the LLM
+ * much better than the two-letter code does. Falls back to the raw
+ * code if the lookup fails so prompts never break.
+ * @param languageCode - the ISO-639-1 code
+ * @returns the English display name, or the raw code if unknown
+ */
+export function getLanguageName(languageCode: string): string {
+    const name = ISO6391.getName(languageCode);
+    return name || languageCode;
+}
+
+/**
  * @param directory - the directory to list all files for
  * @returns all files with their absolute path that exist within the directory, recursively
  */


### PR DESCRIPTION

A prompt audit against Hendy et al. 2023 on GPT-MT prompting and current localization-platform practice (see `.claude/prompt-audit.md` in local notes) surfaced several concrete misses. Fixing them as one item since every change touches the same prompt builders.

## What changes

**Language names instead of codes in prompts.** Prompts now read "from English to French" instead of "from en to fr". The research consistently shows LLMs treat two-letter codes as tokens rather than instructions. A new `getLanguageName()` helper in `utils.ts` wraps `ISO6391.getName()` and falls back to the raw code when the lookup fails, so prompts never break on unknown inputs.

**New `--context <string>` flag** on both `translate` and `diff` subcommands. Threads through `Options` → pipeline options → both prompt builders. Prepends a "Product context: ..." preamble so the model can pick domain-appropriate terminology and tone. Closes issue #453.

**Plural-suffix awareness in the JSON generation prompt.** When any key ends in `_zero` / `_one` / `_two` / `_few` / `_many` / `_other` (CLDR plural forms used by i18next), the prompt now tells the model the suffix is a semantic marker so the target language's correct plural rule is applied instead of the suffix being treated as part of the text.

**`{{NEWLINE}}` placeholder now respects the configured delimiter.** The prompt used to hardcode `{{NEWLINE}}` even when the user passed a custom `--templated-string-prefix` / `--templated-string-suffix`. The prompt now references the same delimiter the runtime actually substitutes.

**`failedTranslationPrompt` fix.** It used to receive only the failed output. Now receives both the original source and the failed output so the retry has something good to anchor on. The retry instruction is also reworded — the previous wording asked the model to "consider it as a concatenation of [output language] words" which was backwards.

**CSV verification merged.** `translationVerificationPrompt` now checks both accuracy and styling in one pass. The standalone `stylingVerificationPrompt` remains for users of `--override-prompt` but defaults to a trivial ACK-only prompt (no extra round-trip). Halves the verification cost without losing coverage, and removes the CSV-line-alignment fragility that showed up when the two prompts disagreed on line counts.

**Removed bracket wrapping** on language codes passed into the pipelines. `[en]` was a legacy quirk that collided with the new name-expansion.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` no errors
- [x] `npm test` — 107 tests pass (90 → 107), 17 new prompt-builder and utility assertions in `src/test/prompts.spec.ts` and `src/test/utils.spec.ts`
- [x] `npx ts-node src/cli.ts translate --help` shows the new `--context` flag with correct help text