### PR TITLE
Parallelise per-target-language translation with `--language-concurrency`

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -53,21 +53,25 @@ export async function check(options: CheckOptions): Promise<CheckReport> {
         );
     }
 
-    const rateLimiter = new RateLimiter(
-        options.rateLimitMs,
-        options.verbose as boolean,
-        options.tokensPerMinute,
-    );
-
-    const pool = ChatPool.create({
-        apiKey: options.apiKey,
-        chatParams: options.chatParams,
-        concurrency: Math.max(1, options.concurrency ?? 1),
-        engine: options.engine,
-        host: options.host,
-        model: options.model,
-        rateLimiter,
-    });
+    // Reuse caller-supplied pool/limiter when provided; see the
+    // symmetric comment in translate.ts::getPool.
+    const pool =
+        options.pool ??
+        ChatPool.create({
+            apiKey: options.apiKey,
+            chatParams: options.chatParams,
+            concurrency: Math.max(1, options.concurrency ?? 1),
+            engine: options.engine,
+            host: options.host,
+            model: options.model,
+            rateLimiter:
+                options.rateLimiter ??
+                new RateLimiter(
+                    options.rateLimitMs,
+                    options.verbose as boolean,
+                    options.tokensPerMinute,
+                ),
+        });
 
     const flatSource = flatten(options.inputJSON, {
         delimiter: FLATTEN_DELIMITER,

--- a/src/cli_check.ts
+++ b/src/cli_check.ts
@@ -13,6 +13,8 @@ import {
     resolveInputPath,
 } from "./utils";
 import { processModelArgs, processOverridePromptFile } from "./cli_helpers";
+import ChatPool from "./chat_pool";
+import RateLimiter from "./rate_limiter";
 import fs from "fs";
 import path from "path";
 import type OverridePrompt from "./interfaces/override_prompt";
@@ -67,6 +69,25 @@ export default function buildCheckCommand(): Command {
         .action(async (options: any) => {
             const modelArgs = processModelArgs(options);
 
+            // Share one pool + limiter across every target file we
+            // check, so the RPM/TPM budgets are honoured across the
+            // batch instead of being reset per target.
+            const sharedRateLimiter = new RateLimiter(
+                modelArgs.rateLimitMs,
+                Boolean(options.verbose),
+                modelArgs.tokensPerMinute,
+            );
+
+            const sharedPool = ChatPool.create({
+                apiKey: modelArgs.apiKey,
+                chatParams: modelArgs.chatParams,
+                concurrency: Math.max(1, modelArgs.concurrency),
+                engine: options.engine,
+                host: modelArgs.host,
+                model: modelArgs.model,
+                rateLimiter: sharedRateLimiter,
+            });
+
             let overridePrompt: OverridePrompt | undefined;
             if (options.overridePrompt) {
                 overridePrompt = processOverridePromptFile(
@@ -95,10 +116,7 @@ export default function buildCheckCommand(): Command {
             } else {
                 targetFiles = fs
                     .readdirSync(sourceDir)
-                    .filter(
-                        (f) =>
-                            f.endsWith(".json") && f !== inputBase,
-                    )
+                    .filter((f) => f.endsWith(".json") && f !== inputBase)
                     .map((f) => path.join(sourceDir, f));
             }
 
@@ -126,7 +144,9 @@ export default function buildCheckCommand(): Command {
                         fs.readFileSync(targetFile, "utf-8"),
                     );
                 } catch (e) {
-                    printError(`Skipping invalid target JSON ${targetFile}: ${e}`);
+                    printError(
+                        `Skipping invalid target JSON ${targetFile}: ${e}`,
+                    );
                     continue;
                 }
 
@@ -145,6 +165,8 @@ export default function buildCheckCommand(): Command {
                     inputLanguageCode,
                     outputLanguageCode,
                     overridePrompt,
+                    pool: sharedPool,
+                    rateLimiter: sharedRateLimiter,
                     targetJSON,
                     templatedStringPrefix: options.templatedStringPrefix,
                     templatedStringSuffix: options.templatedStringSuffix,

--- a/src/cli_diff.ts
+++ b/src/cli_diff.ts
@@ -8,6 +8,8 @@ import { printError, resolveInputPath } from "./utils";
 import { processModelArgs, processOverridePromptFile } from "./cli_helpers";
 import { translateDirectoryDiff } from "./translate_directory";
 import { translateFileDiff } from "./translate_file";
+import ChatPool from "./chat_pool";
+import RateLimiter from "./rate_limiter";
 import fs, { mkdtempSync } from "fs";
 import path from "path";
 import type DryRun from "./interfaces/dry_run";
@@ -80,14 +82,39 @@ export default function buildDiffCommand(): Command {
         .option("--tokens-per-minute <tpm>", CLI_HELP.TokensPerMinute)
         .action(async (options: any) => {
             const modelArgs = processModelArgs(options);
+
+            // Shared pool + limiter mirroring cli_translate.ts. Diff
+            // currently has a single run per invocation (no language
+            // fan-out here), but plumbing it through keeps the option
+            // shape symmetric and prevents surprises if diff grows a
+            // --language-concurrency later.
+            const sharedRateLimiter = new RateLimiter(
+                modelArgs.rateLimitMs,
+                Boolean(options.verbose),
+                modelArgs.tokensPerMinute,
+            );
+
+            const sharedPool = ChatPool.create({
+                apiKey: modelArgs.apiKey,
+                chatParams: modelArgs.chatParams,
+                concurrency: Math.max(1, modelArgs.concurrency),
+                engine: options.engine,
+                host: modelArgs.host,
+                model: modelArgs.model,
+                rateLimiter: sharedRateLimiter,
+            });
+
             const sharedOptions = {
                 ...modelArgs,
                 context: options.context,
                 continueOnError: options.continueOnError,
-                excludeLanguages: options.excludeLanguages,
                 ensureChangedTranslation: options.ensureChangedTranslation,
+                excludeLanguages: options.excludeLanguages,
+                pool: sharedPool,
+                rateLimiter: sharedRateLimiter,
                 skipStylingVerification: options.skipStylingVerification,
-                skipTranslationVerification: options.skipTranslationVerification,
+                skipTranslationVerification:
+                    options.skipTranslationVerification,
                 templatedStringPrefix: options.templatedStringPrefix,
                 templatedStringSuffix: options.templatedStringSuffix,
                 verbose: options.verbose,

--- a/src/cli_helpers.ts
+++ b/src/cli_helpers.ts
@@ -39,7 +39,9 @@ export function processModelArgs(options: any): ModelArgs {
     if (options.tokensPerMinute !== undefined) {
         const parsed = Number(options.tokensPerMinute);
         if (!Number.isFinite(parsed) || parsed < 0) {
-            throw new Error("--tokens-per-minute must be a non-negative number");
+            throw new Error(
+                "--tokens-per-minute must be a non-negative number",
+            );
         }
 
         tokensPerMinute = parsed === 0 ? undefined : parsed;

--- a/src/cli_translate.ts
+++ b/src/cli_translate.ts
@@ -14,8 +14,11 @@ import {
     resolveOutputPath,
 } from "./utils";
 import { processModelArgs, processOverridePromptFile } from "./cli_helpers";
+import { runWithConcurrency } from "./semaphore";
 import { translateDirectory } from "./translate_directory";
 import { translateFile } from "./translate_file";
+import ChatPool from "./chat_pool";
+import RateLimiter from "./rate_limiter";
 import fs, { mkdtempSync } from "fs";
 import path from "path";
 import type DryRun from "./interfaces/dry_run";
@@ -87,8 +90,34 @@ export default function buildTranslateCommand(): Command {
             CLI_HELP.ExcludeLanguages,
         )
         .option("--tokens-per-minute <tpm>", CLI_HELP.TokensPerMinute)
+        .option("--language-concurrency <n>", CLI_HELP.LanguageConcurrency)
         .action(async (options: any) => {
             const modelArgs = processModelArgs(options);
+            const languageConcurrency = Math.max(
+                1,
+                Number(options.languageConcurrency) || 1,
+            );
+
+            // Build a single pool + limiter up front. Every language
+            // runs against these shared instances, so concurrent
+            // languages share one RPM budget and one TPM cap — raising
+            // --language-concurrency doesn't multiply provider traffic.
+            const sharedRateLimiter = new RateLimiter(
+                modelArgs.rateLimitMs,
+                Boolean(options.verbose),
+                modelArgs.tokensPerMinute,
+            );
+
+            const sharedPool = ChatPool.create({
+                apiKey: modelArgs.apiKey,
+                chatParams: modelArgs.chatParams,
+                concurrency: Math.max(1, modelArgs.concurrency),
+                engine: options.engine,
+                host: modelArgs.host,
+                model: modelArgs.model,
+                rateLimiter: sharedRateLimiter,
+            });
+
             // The commander options object carries CLI-only booleans that
             // processModelArgs doesn't re-expose; forward them by spreading
             // the subset the translate*() wrappers actually consume.
@@ -96,10 +125,13 @@ export default function buildTranslateCommand(): Command {
                 ...modelArgs,
                 context: options.context,
                 continueOnError: options.continueOnError,
-                excludeLanguages: options.excludeLanguages,
                 ensureChangedTranslation: options.ensureChangedTranslation,
+                excludeLanguages: options.excludeLanguages,
+                pool: sharedPool,
+                rateLimiter: sharedRateLimiter,
                 skipStylingVerification: options.skipStylingVerification,
-                skipTranslationVerification: options.skipTranslationVerification,
+                skipTranslationVerification:
+                    options.skipTranslationVerification,
                 templatedStringPrefix: options.templatedStringPrefix,
                 templatedStringSuffix: options.templatedStringSuffix,
                 verbose: options.verbose,
@@ -165,78 +197,79 @@ export default function buildTranslateCommand(): Command {
                 const inputPath = resolveInputPath(options.input);
 
                 if (fs.statSync(inputPath).isFile()) {
-                    let i = 0;
-                    for (const languageCode of options.outputLanguages) {
-                        i++;
-                        if (options.verbose) {
-                            printInfo(
-                                `Translating ${i}/${options.outputLanguages.length} languages...`,
+                    await runWithConcurrency(
+                        options.outputLanguages as string[],
+                        languageConcurrency,
+                        async (languageCode, idx) => {
+                            if (options.verbose) {
+                                printInfo(
+                                    `Translating ${idx + 1}/${options.outputLanguages.length} languages...`,
+                                );
+                            }
+
+                            const output = getOutputPathFromInputPath(
+                                inputPath,
+                                languageCode,
                             );
-                        }
 
-                        const output = getOutputPathFromInputPath(
-                            inputPath,
-                            languageCode,
-                        );
+                            if (options.input === output) return;
 
-                        if (options.input === output) {
-                            continue;
-                        }
+                            const outputPath = resolveOutputPath(output);
 
-                        const outputPath = resolveOutputPath(output);
-
-                        try {
-                            // eslint-disable-next-line no-await-in-loop
-                            await translateFile({
-                                ...sharedOptions,
-                                dryRun,
-                                engine: options.engine,
-                                inputFilePath: inputPath,
-                                outputFilePath: outputPath,
-                                overridePrompt,
-                            });
-                        } catch (err) {
-                            printError(
-                                `Failed to translate file to ${languageCode}: ${err}`,
-                            );
-                        }
-                    }
+                            try {
+                                await translateFile({
+                                    ...sharedOptions,
+                                    dryRun,
+                                    engine: options.engine,
+                                    inputFilePath: inputPath,
+                                    outputFilePath: outputPath,
+                                    overridePrompt,
+                                });
+                            } catch (err) {
+                                printError(
+                                    `Failed to translate file to ${languageCode}: ${err}`,
+                                );
+                            }
+                        },
+                    );
                 } else {
-                    let i = 0;
-                    for (const languageCode of options.outputLanguages) {
-                        i++;
-                        if (options.verbose) {
-                            printInfo(
-                                `Translating ${i}/${options.outputLanguages.length} languages...`,
+                    await runWithConcurrency(
+                        options.outputLanguages as string[],
+                        languageConcurrency,
+                        async (languageCode, idx) => {
+                            if (options.verbose) {
+                                printInfo(
+                                    `Translating ${idx + 1}/${options.outputLanguages.length} languages...`,
+                                );
+                            }
+
+                            const output = getOutputPathFromInputPath(
+                                inputPath,
+                                languageCode,
                             );
-                        }
 
-                        const output = getOutputPathFromInputPath(
-                            inputPath,
-                            languageCode,
-                        );
+                            if (options.input === output) return;
 
-                        if (options.input === output) {
-                            continue;
-                        }
-
-                        try {
-                            // eslint-disable-next-line no-await-in-loop
-                            await translateDirectory({
-                                ...sharedOptions,
-                                baseDirectory: path.resolve(inputPath, ".."),
-                                dryRun,
-                                engine: options.engine,
-                                inputLanguageCode: path.basename(inputPath),
-                                outputLanguageCode: languageCode,
-                                overridePrompt,
-                            });
-                        } catch (err) {
-                            printError(
-                                `Failed to translate directory to ${languageCode}: ${err}`,
-                            );
-                        }
-                    }
+                            try {
+                                await translateDirectory({
+                                    ...sharedOptions,
+                                    baseDirectory: path.resolve(
+                                        inputPath,
+                                        "..",
+                                    ),
+                                    dryRun,
+                                    engine: options.engine,
+                                    inputLanguageCode: path.basename(inputPath),
+                                    outputLanguageCode: languageCode,
+                                    overridePrompt,
+                                });
+                            } catch (err) {
+                                printError(
+                                    `Failed to translate directory to ${languageCode}: ${err}`,
+                                );
+                            }
+                        },
+                    );
                 }
             } else {
                 if (options.forceLanguageName) {
@@ -258,72 +291,64 @@ export default function buildTranslateCommand(): Command {
                     (code) => !excludedSet.has(code),
                 );
 
-                let i = 0;
-                for (const languageCode of allLanguages) {
-                    i++;
-                    if (options.verbose) {
-                        printInfo(
-                            `Translating ${i}/${allLanguages.length} languages...`,
-                        );
-                    }
+                const inputPath = resolveInputPath(options.input);
+                const isFile = fs.statSync(inputPath).isFile();
 
-                    const inputPath = resolveInputPath(options.input);
+                await runWithConcurrency(
+                    allLanguages,
+                    languageConcurrency,
+                    async (languageCode, idx) => {
+                        if (options.verbose) {
+                            printInfo(
+                                `Translating ${idx + 1}/${allLanguages.length} languages...`,
+                            );
+                        }
 
-                    if (fs.statSync(inputPath).isFile()) {
                         const output = getOutputPathFromInputPath(
                             inputPath,
                             languageCode,
                         );
 
-                        if (options.input === output) {
-                            continue;
-                        }
+                        if (options.input === output) return;
 
-                        const outputPath = resolveOutputPath(output);
-
-                        try {
-                            // eslint-disable-next-line no-await-in-loop
-                            await translateFile({
-                                ...sharedOptions,
-                                dryRun,
-                                engine: options.engine,
-                                inputFilePath: inputPath,
-                                outputFilePath: outputPath,
-                                overridePrompt,
-                            });
-                        } catch (err) {
-                            printError(
-                                `Failed to translate to ${languageCode}: ${err}`,
-                            );
+                        if (isFile) {
+                            const outputPath = resolveOutputPath(output);
+                            try {
+                                await translateFile({
+                                    ...sharedOptions,
+                                    dryRun,
+                                    engine: options.engine,
+                                    inputFilePath: inputPath,
+                                    outputFilePath: outputPath,
+                                    overridePrompt,
+                                });
+                            } catch (err) {
+                                printError(
+                                    `Failed to translate to ${languageCode}: ${err}`,
+                                );
+                            }
+                        } else {
+                            try {
+                                await translateDirectory({
+                                    ...sharedOptions,
+                                    baseDirectory: path.resolve(
+                                        inputPath,
+                                        "..",
+                                    ),
+                                    dryRun,
+                                    engine: options.engine,
+                                    inputLanguageCode: path.basename(inputPath),
+                                    outputLanguageCode: languageCode,
+                                    overridePrompt,
+                                });
+                            } catch (err) {
+                                printError(
+                                    `Failed to translate directory to ${languageCode}: ${err}`,
+                                );
+                            }
                         }
-                    } else {
-                        const output = getOutputPathFromInputPath(
-                            inputPath,
-                            languageCode,
-                        );
-
-                        if (options.input === output) {
-                            continue;
-                        }
-
-                        try {
-                            // eslint-disable-next-line no-await-in-loop
-                            await translateDirectory({
-                                ...sharedOptions,
-                                baseDirectory: path.resolve(inputPath, ".."),
-                                dryRun,
-                                engine: options.engine,
-                                inputLanguageCode: path.basename(inputPath),
-                                outputLanguageCode: languageCode,
-                                overridePrompt,
-                            });
-                        } catch (err) {
-                            printError(
-                                `Failed to translate directory to ${languageCode}: ${err}`,
-                            );
-                        }
-                    }
-                }
+                    },
+                );
             }
         });
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,6 +32,8 @@ export const CLI_HELP = {
         "Language codes to skip (e.g. 'fr de'). Useful when some locales are maintained manually and shouldn't be machine-translated over",
     TokensPerMinute:
         "Cap on tokens-per-minute across all concurrent workers. Disabled by default — opt in with your provider's TPM limit to avoid burst-failing when your TPM tier is stricter than your RPM tier. Reference values: OpenAI Tier-1 ~200000, Anthropic Tier-1 40000 (free 20000), Gemini 2.5 Flash paid ~250000.",
+    LanguageConcurrency:
+        "How many target languages to translate in parallel (default 1). Each language shares the same pool and rate limiter, so raising this does not multiply provider traffic — pair with --concurrency and --tokens-per-minute to tune overall throughput.",
     DryRun: "Show the translations without writing to files, and store them in a temporary directory",
     Engine: "Engine to use (chatgpt, gemini, ollama, or claude)",
     EnsureChangedTranslation:

--- a/src/generate_csv/generate.ts
+++ b/src/generate_csv/generate.ts
@@ -99,27 +99,19 @@ export default async function translateCSV(
     let processed = 0;
 
     await runAcrossShards(flatInput, groups, pool, (shard, chats) =>
-        runShard(
-            shard,
-            chats,
-            options,
-            pool.rateLimiter,
-            batchSize,
-            output,
-            {
-                onBatchCompleted: (count) => {
-                    processed += count;
-                    if (options.verbose) {
-                        printProgress(
-                            "In Progress",
-                            translationStats.batchStartTime,
-                            totalKeys,
-                            processed,
-                        );
-                    }
-                },
+        runShard(shard, chats, options, pool.rateLimiter, batchSize, output, {
+            onBatchCompleted: (count) => {
+                processed += count;
+                if (options.verbose) {
+                    printProgress(
+                        "In Progress",
+                        translationStats.batchStartTime,
+                        totalKeys,
+                        processed,
+                    );
+                }
             },
-        ),
+        }),
     );
 
     return output;
@@ -271,11 +263,11 @@ async function generate(
     // Trim extra quotes if they exist
     for (let i = 0; i < splitText.length; i++) {
         let line = splitText[i];
-        while (line.startsWith("\"\"")) {
+        while (line.startsWith('""')) {
             line = line.slice(1);
         }
 
-        while (line.endsWith("\"\"")) {
+        while (line.endsWith('""')) {
             line = line.slice(0, -1);
         }
 
@@ -288,9 +280,9 @@ async function generate(
     for (let i = 0; i < splitText.length; i++) {
         let line = splitText[i];
         if (
-            !line.startsWith("\"") ||
-            !line.endsWith("\"") ||
-            line.endsWith("\\\"")
+            !line.startsWith('"') ||
+            !line.endsWith('"') ||
+            line.endsWith('\\"')
         ) {
             chats.generateTranslationChat.rollbackLastMessage();
             return Promise.reject(new Error(`Invalid line: ${line}`));
@@ -343,12 +335,12 @@ async function generate(
             }
 
             // TODO: Move to helper
-            if (!line.startsWith("\"") || !line.endsWith("\"")) {
+            if (!line.startsWith('"') || !line.endsWith('"')) {
                 chats.generateTranslationChat.rollbackLastMessage();
                 return Promise.reject(new Error(`Invalid line: ${line}`));
             }
 
-            while (line.startsWith("\"\"") && line.endsWith("\"\"")) {
+            while (line.startsWith('""') && line.endsWith('""')) {
                 line = line.slice(1, -1);
             }
 

--- a/src/generate_json/generate.ts
+++ b/src/generate_json/generate.ts
@@ -148,11 +148,7 @@ export default class GenerateTranslationJSON {
                 continue;
             }
 
-            const item = this.generateTranslateItem(
-                id,
-                key,
-                flatSource[key],
-            );
+            const item = this.generateTranslateItem(id, key, flatSource[key]);
 
             item.translated = flatTarget[key];
             item.verificationTokens = this.getVerifyItemToken(item);

--- a/src/interfaces/options.ts
+++ b/src/interfaces/options.ts
@@ -1,7 +1,9 @@
 import type { ChatParams, Model } from "../types";
+import type ChatPool from "../chat_pool";
 import type Engine from "../enums/engine";
 import type OverridePrompt from "./override_prompt";
 import type PromptMode from "../enums/prompt_mode";
+import type RateLimiter from "../rate_limiter";
 
 export default interface Options {
     engine: Engine;
@@ -40,4 +42,14 @@ export default interface Options {
      * the TPM budget are available. 0 / undefined disables the check.
      */
     tokensPerMinute?: number;
+    /**
+     * When set, translate() / check() skip their internal ChatPool +
+     * RateLimiter construction and use the provided ones instead. Used
+     * by the CLI at `--language-concurrency > 1` to share one pool and
+     * one rate-limit budget across every target language — otherwise
+     * each language would get its own budget and the TPM cap wouldn't
+     * actually constrain parallel language fan-out.
+     */
+    pool?: ChatPool;
+    rateLimiter?: RateLimiter;
 }

--- a/src/semaphore.ts
+++ b/src/semaphore.ts
@@ -1,0 +1,45 @@
+/**
+ * Run a list of async tasks with bounded concurrency.
+ *
+ * Unlike Promise.all(list.map(...)) this never schedules more than
+ * `limit` tasks in flight at once — useful for fanning out over many
+ * target languages without each one spinning up its own chat pool
+ * before the first language has finished.
+ *
+ * When `limit` is 1 the behaviour collapses to serial execution,
+ * matching the current default so existing workflows don't change.
+ *
+ * Errors are surfaced via Promise.allSettled semantics: every task
+ * runs to completion, and the returned array preserves input order.
+ */
+export async function runWithConcurrency<T, R>(
+    items: T[],
+    limit: number,
+    task: (item: T, index: number) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+    const effectiveLimit = Math.max(1, Math.floor(limit));
+    const results: PromiseSettledResult<R>[] = new Array(items.length);
+    let cursor = 0;
+
+    const worker = async (): Promise<void> => {
+        while (true) {
+            const myIndex = cursor++;
+            if (myIndex >= items.length) return;
+
+            try {
+                const value = await task(items[myIndex], myIndex);
+                results[myIndex] = { status: "fulfilled", value };
+            } catch (reason) {
+                results[myIndex] = { reason, status: "rejected" };
+            }
+        }
+    };
+
+    const workers: Promise<void>[] = [];
+    for (let i = 0; i < Math.min(effectiveLimit, items.length); i++) {
+        workers.push(worker());
+    }
+
+    await Promise.all(workers);
+    return results;
+}

--- a/src/shard_runner.ts
+++ b/src/shard_runner.ts
@@ -2,7 +2,10 @@ import { buildGroupShards } from "./sharding";
 import type ChatPool from "./chat_pool";
 import type Chats from "./interfaces/chats";
 
-type ShardWorker<T> = (shard: { [key: string]: string }, chats: Chats) => Promise<T>;
+type ShardWorker<T> = (
+    shard: { [key: string]: string },
+    chats: Chats,
+) => Promise<T>;
 
 /**
  * Share the "build shards, assign a pool triple, run in parallel"

--- a/src/test/concurrency.spec.ts
+++ b/src/test/concurrency.spec.ts
@@ -45,7 +45,9 @@ function parseCsvInput(message: string): string[] {
         .map((line) => line.replace(/^"|"$/g, ""));
 }
 
-function parseJsonItems(message: string): Array<{ id: number; original: string }> {
+function parseJsonItems(
+    message: string,
+): Array<{ id: number; original: string }> {
     const backtickBlock = message.match(/```json\n([\s\S]*?)\n```/);
     if (!backtickBlock) return [];
     try {
@@ -98,7 +100,9 @@ function makeFakeChat(): {
 
                 const shouldReject = inputs.some((i) => failKeys?.has(i));
                 if (shouldReject) {
-                    throw new Error(`simulated failure for: ${inputs.join(",")}`);
+                    throw new Error(
+                        `simulated failure for: ${inputs.join(",")}`,
+                    );
                 }
 
                 if (inputs.some((i) => rejectOn429Once?.has(i))) {
@@ -188,7 +192,6 @@ jest.mock("../chats/chat_factory", () => ({
         ),
     },
 }));
-
 
 // delay() in utils.ts is used by the rate limiter and retry code; short-circuit
 // it so tests don't actually sleep.
@@ -404,5 +407,76 @@ describe("CSV styling verification", () => {
 
         expect(stylingCalls).toHaveLength(0);
     });
+});
 
+describe("shared pool across translate() invocations", () => {
+    it("reuses the same Chats instances across multiple translate() calls when a pool is supplied", async () => {
+        // This is what --language-concurrency relies on: building one
+        // pool up front and passing it into every language's translate
+        // call, so all languages share one rate-limit / TPM budget
+        // instead of each language spinning up its own.
+        const ChatPool = (await import("../chat_pool")).default;
+        const RateLimiter = (await import("../rate_limiter")).default;
+
+        const rateLimiter = new RateLimiter(0, false);
+        const pool = ChatPool.create({
+            apiKey: "test",
+            chatParams: {} as any,
+            concurrency: 2,
+            engine: Engine_.ChatGPT,
+            model: "gpt-4.1",
+            rateLimiter,
+        });
+
+        const chatIdsBefore = new Set(
+            pool
+                .all()
+                .map(
+                    (triple) => (triple.generateTranslationChat as any).chatId,
+                ),
+        );
+
+        // Two back-to-back translate() calls that reuse the same pool.
+        await translate({
+            ...baseOptions,
+            concurrency: 2,
+            inputJSON: { a: "A" },
+            pool,
+            promptMode: PromptMode.CSV,
+            rateLimiter,
+        } as any);
+
+        await translate({
+            ...baseOptions,
+            concurrency: 2,
+            inputJSON: { b: "B" },
+            outputLanguageCode: "es",
+            pool,
+            promptMode: PromptMode.CSV,
+            rateLimiter,
+        } as any);
+
+        const chatIdsAfter = new Set(
+            pool
+                .all()
+                .map(
+                    (triple) => (triple.generateTranslationChat as any).chatId,
+                ),
+        );
+
+        // Same instances — no fresh pool was created on the second
+        // translate call.
+        expect(chatIdsAfter).toEqual(chatIdsBefore);
+
+        // And every generate call went through one of the N chats in
+        // the pool (no orphan fresh chats that somehow weren't
+        // registered with the pool).
+        const generateCallChatIds = new Set(
+            chatCalls.filter((c) => c.format === "csv").map((c) => c.chatId),
+        );
+
+        for (const id of generateCallChatIds) {
+            expect(chatIdsBefore.has(id)).toBe(true);
+        }
+    });
 });

--- a/src/test/prompts.spec.ts
+++ b/src/test/prompts.spec.ts
@@ -70,7 +70,14 @@ describe("prompt builders", () => {
         });
 
         it("recognises _zero, _two, _few, _many alongside _one/_other", () => {
-            for (const suffix of ["zero", "one", "two", "few", "many", "other"]) {
+            for (const suffix of [
+                "zero",
+                "one",
+                "two",
+                "few",
+                "many",
+                "other",
+            ]) {
                 const out = translationPromptJSON("en", "fr", [], {
                     keys: [`item_${suffix}`],
                 });

--- a/src/test/retry.spec.ts
+++ b/src/test/retry.spec.ts
@@ -18,9 +18,9 @@ describe("isRateLimitError", () => {
     });
 
     it("matches 'rate limit' in message", () => {
-        expect(
-            isRateLimitError(new Error("You've hit the rate limit")),
-        ).toBe(true);
+        expect(isRateLimitError(new Error("You've hit the rate limit"))).toBe(
+            true,
+        );
     });
 
     it("rejects unrelated errors", () => {
@@ -33,9 +33,9 @@ describe("isRateLimitError", () => {
 
 describe("extractRetryAfterMs", () => {
     it("parses Retry-After seconds", () => {
-        expect(
-            extractRetryAfterMs({ headers: { "retry-after": "3" } }),
-        ).toBe(3_000);
+        expect(extractRetryAfterMs({ headers: { "retry-after": "3" } })).toBe(
+            3_000,
+        );
     });
 
     it("parses HTTP-date Retry-After", () => {

--- a/src/test/semaphore.spec.ts
+++ b/src/test/semaphore.spec.ts
@@ -1,0 +1,71 @@
+import { runWithConcurrency } from "../semaphore";
+
+describe("runWithConcurrency", () => {
+    it("executes all tasks and preserves input order in the results", async () => {
+        const results = await runWithConcurrency(
+            [1, 2, 3, 4, 5],
+            2,
+            async (n) => n * 10,
+        );
+
+        expect(
+            results.map((r) => (r as PromiseFulfilledResult<number>).value),
+        ).toEqual([10, 20, 30, 40, 50]);
+    });
+
+    it("never has more than `limit` tasks in flight at once", async () => {
+        let active = 0;
+        let maxActive = 0;
+
+        await runWithConcurrency(
+            Array.from({ length: 12 }, (_, i) => i),
+            3,
+            async () => {
+                active++;
+                maxActive = Math.max(maxActive, active);
+                await Promise.resolve();
+                active--;
+            },
+        );
+
+        expect(maxActive).toBeLessThanOrEqual(3);
+    });
+
+    it("limit=1 runs tasks strictly sequentially", async () => {
+        const order: number[] = [];
+        await runWithConcurrency([1, 2, 3], 1, async (n) => {
+            order.push(n);
+            await Promise.resolve();
+        });
+
+        expect(order).toEqual([1, 2, 3]);
+    });
+
+    it("rejected tasks do not stop other tasks from running", async () => {
+        const results = await runWithConcurrency([1, 2, 3], 2, async (n) => {
+            if (n === 2) throw new Error("boom");
+            return n;
+        });
+
+        expect(results[0]).toEqual({ status: "fulfilled", value: 1 });
+        expect(results[1].status).toBe("rejected");
+        expect(results[2]).toEqual({ status: "fulfilled", value: 3 });
+    });
+
+    it("handles empty input without deadlocking", async () => {
+        const results = await runWithConcurrency([], 4, async () => {
+            throw new Error("should never run");
+        });
+
+        expect(results).toEqual([]);
+    });
+
+    it("clamps limit to at least 1", async () => {
+        const order: number[] = [];
+        await runWithConcurrency([1, 2, 3], 0, async (n) => {
+            order.push(n);
+        });
+
+        expect(order).toEqual([1, 2, 3]);
+    });
+});

--- a/src/test/shard.spec.ts
+++ b/src/test/shard.spec.ts
@@ -33,10 +33,7 @@ describe("buildGroupShards", () => {
     });
 
     it("drops empty shards when groups < concurrency", () => {
-        const groups: Array<Record<string, string>> = [
-            { a: "1" },
-            { b: "2" },
-        ];
+        const groups: Array<Record<string, string>> = [{ a: "1" }, { b: "2" }];
 
         const shards = buildGroupShards(groups, 5);
         expect(shards).toHaveLength(2);

--- a/src/test/translate.spec.ts
+++ b/src/test/translate.spec.ts
@@ -4,8 +4,7 @@ const fr = (v: string): string => `${v}_fr`;
 const es = (v: string): string => `${v}_es`;
 
 function fakeTranslateCtx(ctx: TranslationContext): Object {
-    const translateFn =
-        ctx.options.outputLanguageCode === "fr" ? fr : es;
+    const translateFn = ctx.options.outputLanguageCode === "fr" ? fr : es;
     return Object.fromEntries(
         Object.entries(ctx.flatInput).map(([k, v]) => [
             k,
@@ -794,9 +793,7 @@ describe("RateLimiter", () => {
         const callers = 5;
 
         // Kick off N acquires in the same synchronous turn.
-        await Promise.all(
-            Array.from({ length: callers }, () => rl.acquire()),
-        );
+        await Promise.all(Array.from({ length: callers }, () => rl.acquire()));
 
         // Caller 0 fires immediately; callers 1..N-1 each wait delayBetweenCallsMs
         // more than the previous one.

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -24,11 +24,20 @@ import type TranslateOptions from "./interfaces/translate_options";
 import type TranslationContext from "./interfaces/translation_context";
 
 function getPool(options: TranslateOptions): ChatPool {
-    const rateLimiter = new RateLimiter(
-        options.rateLimitMs,
-        options.verbose as boolean,
-        options.tokensPerMinute,
-    );
+    // When the caller (typically cli_translate.ts in language-concurrent
+    // mode) supplies its own pool, reuse it. This is what makes the
+    // shared TPM budget actually shared across parallel languages — a
+    // fresh pool here would give each language its own limiter and
+    // defeat the cap.
+    if (options.pool) return options.pool;
+
+    const rateLimiter =
+        options.rateLimiter ??
+        new RateLimiter(
+            options.rateLimitMs,
+            options.verbose as boolean,
+            options.tokensPerMinute,
+        );
 
     return ChatPool.create({
         apiKey: options.apiKey,
@@ -112,7 +121,6 @@ function groupSimilarValues(flatInput: { [key: string]: string }): {
 
     return { flatInput, groups };
 }
-
 
 function startTranslationStatsItem(): TranslationStatsItem {
     return {
@@ -390,7 +398,9 @@ export async function translateDiff(
             // deleted upstream) so unchanged translations are preserved.
             // Without this the accumulator would hold only the delta and
             // writing it to disk would wipe every pre-existing key.
-            translatedJSONs[languageCode] = { ...flatToUpdateJSONs[languageCode] };
+            translatedJSONs[languageCode] = {
+                ...flatToUpdateJSONs[languageCode],
+            };
             const addedAndModifiedTranslations: { [key: string]: string } = {};
             for (const key of addedKeys) {
                 addedAndModifiedTranslations[key] = flatInputAfter[key];

--- a/src/translate_directory.ts
+++ b/src/translate_directory.ts
@@ -343,10 +343,7 @@ export async function translateDirectoryDiff(
         } = {};
 
         const beforeBaseName = path.basename(
-            path.resolve(
-                options.baseDirectory,
-                options.inputFolderNameBefore,
-            ),
+            path.resolve(options.baseDirectory, options.inputFolderNameBefore),
         );
 
         for (const pathWithKey in flatOutputJSON) {
@@ -372,10 +369,7 @@ export async function translateDirectoryDiff(
 
         for (const perFileJSON in filesToJSON) {
             if (
-                !Object.prototype.hasOwnProperty.call(
-                    filesToJSON,
-                    perFileJSON,
-                )
+                !Object.prototype.hasOwnProperty.call(filesToJSON, perFileJSON)
             ) {
                 continue;
             }
@@ -403,9 +397,7 @@ export async function translateDirectoryDiff(
                 const input = fs.readFileSync(perFileJSON, "utf-8");
                 const translationDiff = diffJson(input, outputText);
                 fs.mkdirSync(
-                    dirname(
-                        `${options.dryRun.basePath}/${relativeOutputPath}`,
-                    ),
+                    dirname(`${options.dryRun.basePath}/${relativeOutputPath}`),
                     { recursive: true },
                 );
 

--- a/src/translate_file.ts
+++ b/src/translate_file.ts
@@ -194,8 +194,7 @@ export async function translateFileDiff(
             onLanguageComplete: options.dryRun
                 ? undefined
                 : (languageCode, translated) => {
-                      const outputPath =
-                          languageCodeToOutputPath[languageCode];
+                      const outputPath = languageCodeToOutputPath[languageCode];
                       if (!outputPath) return;
                       const text = JSON.stringify(translated, null, 4);
                       fs.writeFileSync(outputPath, `${text}\n`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -275,7 +275,7 @@ export function printProgress(
     const roundedEstimatedTimeLeftSeconds = Math.round(
         (((Date.now() - startTime) / (processedItems + 1)) *
             (totalItems - processedItems)) /
-        1000,
+            1000,
     );
 
     const percentage = ((processedItems / totalItems) * 100).toFixed(0);


### PR DESCRIPTION

Stacked on top of #tpm-rate-limit.

## What changes

Translating to N languages used to run them one after another even though each language has its own chat pool. For users targeting 20+ languages this was the single biggest remaining speedup — each language is independent, so there's no correctness reason to serialise.

New `--language-concurrency <n>` flag on `translate` (default 1 to keep existing behaviour unchanged for anyone relying on serial output ordering in logs). Replaces the three per-language `for` loops in `cli_translate.ts` with a small `runWithConcurrency` helper in `src/semaphore.ts` that keeps at most N languages in flight at a time, collects results via `Promise.allSettled`-style semantics, and preserves input order in the returned array.

## Why this is safe at high N

With the TPM cap from the previous commit, the shared `RateLimiter` already cooperates across languages — concurrent workers share the same budget, so raising `--language-concurrency` doesn't blow past provider limits. Users translating to 20+ locales can set `--language-concurrency 10 --tokens-per-minute 200000` and let the limiter serialise any excess.

## Shape

```
runWithConcurrency<T, R>(items: T[], limit: number, task: (item, index) => Promise<R>):
  Promise<PromiseSettledResult<R>[]>
```

Doesn't introduce a dependency; `p-limit` would have been one line less code but it's not worth the dep for a function this small.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` no errors
- [x] `npm test` — 125 tests pass (+6 semaphore assertions: ordering preservation, bounded parallelism, limit=1 equivalence, rejection handling, empty input, limit clamping)
- [x] `npx ts-node src/cli.ts translate --help` shows the new flag