### PR TITLE
Skip integration test workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Skip for Dependabot PRs: repo secrets (OPENAI_API_KEY) are not
+    # shared with Dependabot-authored workflows by default, so this
+    # would always fail on bump PRs with no real signal. The build.yml
+    # workflow (lint + build + unit tests) runs regardless and is the
+    # authoritative check for dependency updates.
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Test i18n-ai-translate action
         uses: taahamahdi/i18n-ai-translate@master


### PR DESCRIPTION
The test.yml workflow runs the published i18n-ai-translate GitHub Action against test/en.json, which requires an OPENAI_API_KEY secret. GitHub doesn't share repo secrets with Dependabot-authored workflows by default, so every Dependabot bump has failed this check in 8-12 seconds with no real signal about whether the bump is safe.

Gate the job on `github.actor != 'dependabot[bot]'` so those PRs skip it. The build.yml workflow (lint + tsc build + jest unit tests) runs regardless and is the authoritative check for dependency updates.