### PR TITLE
Refresh docs and bump to v5.0.0

### DIFF
--- a/ADVANCED_GUIDE.md
+++ b/ADVANCED_GUIDE.md
@@ -2,22 +2,27 @@
 
 Leverage ChatGPT, Gemini, Ollama, or Claude for seamless translation of localization files. Supports directories of nested translation files. Requires [i18next-style](https://github.com/i18next/i18next) JSON files.
 
-##### CSV Mode
+## Pipelines
 
-Three prompts are chained to ensure each translation is well-formed.
+### CSV Mode
 
-1. The [translation prompt](#translation-prompt) attempts a translation
-2. The [translation verification prompt](#translation-verification-prompt) uses a separate context to verify the translation
-3. The [styling verification prompt](#styling-verification-prompt) uses yet another context to verify the translation's formatting is consistent with the source
+Two prompts per batch: translate, then verify accuracy-and-styling together. Faster, but relies on the model following a precise line-per-line format — works well with GPT-class models, poorly with smaller ones.
 
-##### JSON Mode
+1. The [translation prompt](#csv-translation-prompt) attempts a translation.
+2. The [verification prompt](#csv-verification-prompt) uses a separate context to flag any accuracy or styling drift. (If you supply a custom `stylingVerificationPrompt` via `--override-prompt`, a second verify call runs; otherwise the merged verify is the only one.)
 
-Translation and verification is done in two separate steps.
+### JSON Mode
 
-1. The [translation prompt](#translation-prompt-json) attempts to translate the whole file
-2. The [translation verification prompt](#translation-verification-prompt-json) verifies/fixes and verifies again each line.
+Structured-output translation using Zod schemas. Works with weaker models but is ~50% slower.
 
-History is retained between calls to ensure consistency when translating the entire file.
+1. The [translation prompt](#json-translation-prompt) translates the whole batch and returns JSON validated against a Zod schema.
+2. The [verification prompt](#json-verification-prompt) per-item verifies and fixes.
+
+Chat history is retained across batches inside one worker so the model builds consistent terminology; parallel workers each have their own history.
+
+### Parallelism
+
+Batches run in parallel inside one language (`--concurrency`, default 2). Multiple target languages can run concurrently too (`--language-concurrency`, default 1). All workers share one `RateLimiter` — a 429 on any worker backs off every worker via `Retry-After`, and `--tokens-per-minute` enforces a cross-worker TPM cap when the provider's TPM tier is tighter than its RPM tier. Similar-valued strings are grouped and sharded across workers so each worker's chat history stays topically coherent.
 
 https://github.com/user-attachments/assets/4909bf01-3e7a-464a-9c6e-2d1b82cc47d0
 
@@ -26,12 +31,17 @@ https://github.com/user-attachments/assets/4909bf01-3e7a-464a-9c6e-2d1b82cc47d0
         - [GitHub Actions](#github-actions)
         - [Running directly](#running-directly)
         - [Running as a script in your own project](#running-as-a-script-in-your-own-project)
-    - [Script](#script)
-        - [Example usage](#example-usage)
+    - [Subcommands](#subcommands)
+        - [`translate`](#translate)
+        - [`diff`](#diff)
+        - [`check`](#check)
     - [As a library](#as-a-library)
-- [Translation prompt](#translation-prompt)
-- [Translation verification prompt](#translation-verification-prompt)
-- [Styling verification prompt](#styling-verification-prompt)
+- [Concurrency & rate limits](#concurrency--rate-limits)
+- [Prompt reference](#prompt-reference)
+    - [CSV translation prompt](#csv-translation-prompt)
+    - [CSV verification prompt](#csv-verification-prompt)
+    - [JSON translation prompt](#json-translation-prompt)
+    - [JSON verification prompt](#json-verification-prompt)
 - [Prompt overriding](#prompt-overriding)
 - [Dry-run mode](#dry-run-mode)
 
@@ -65,7 +75,7 @@ jobs:
                   api-key: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-### [Running directly](#script)
+### Running directly
 
 ```bash
 git clone git@github.com:taahamahdi/i18n-ai-translate.git
@@ -74,86 +84,38 @@ yarn
 cp /home/en.json jsons/
 
 # Generate French translations
-npm run i18n-ai-translate -- translate -i en.json -o fr.json --engine chatgpt --model gpt-4o --api-key <openai_key>
+npm run i18n-ai-translate -- translate -i en.json -o fr --engine chatgpt --model gpt-5.2 --api-key <openai_key>
 ```
 
-### [Running as a script in your own project](#script)
+### Running as a script in your own project
 
 ```bash
 yarn add i18n-ai-translate
 
 # Generate French translations
-npx i18n-ai-translate translate -i en.json -o fr.json --engine gemini --model gemini-2.0-flash-exp --api-key <gemini_key>
+npx i18n-ai-translate translate -i en.json -o fr --engine gemini --model gemini-2.5-flash --api-key <gemini_key>
 
 # Or, assuming you already have other translations in the current directory
-npx i18n-ai-translate diff --before en-before.json --after en.json --input-language English --engine claude --model claude-3-5-sonnet-latest --api-key <anthropic_key>
+npx i18n-ai-translate diff --before en-before.json --after en.json --input-language en --engine claude --model claude-sonnet-4-6 --api-key <anthropic_key>
 ```
 
-### [Running as a library](#as-a-library)
+## Subcommands
 
-```ts
-import { translate } from "i18n-ai-translate";
-...
-const englishJSON = {
-  "welcomeMessage": "Welcome, {{name}}!",
-  "messages": {
-    "notifications_one": "You have one notification",
-    "notifications_other": "You have {{count}} notifications",
-    "delete": "Would you like to delete the \"{{name}}\" category?"
-  }
-};
+Create a `.env` file with your API key, or pass `--api-key` (`-k`):
 
-const frenchTranslation = await translate({
-  inputJSON: englishJSON,
-  inputLanguageCode: "en",
-  outputLanguageCode: "fr",
-  ...
-});
-
-console.log(frenchTranslation);
-```
-
-```json
-{
-    "welcomeMessage": "Bienvenue, {{name}} !",
-    "messages": {
-        "notifications_one": "Vous avez une notification",
-        "notifications_other": "Vous avez {{count}} notifications",
-        "delete": "Voulez-vous supprimer la catégorie « {{name}} » ?"
-    }
-}
-```
-
-## Script
-
-Use `i18n-ai-translate translate` to convert a local i18n JSON file to any language. Relative paths begin from the `jsons/` directory.
-
-Use `i18n-ai-translate diff` to find the differences between two versions of a source language file, and apply them to all language files in the same directory.
-
-Create a `.env` file with an entry for your API key, or pass the `--api-key` flag.
-
-- `GEMINI_API_KEY=<your Gemini API key>`
 - `OPENAI_API_KEY=<your OpenAI API key>`
+- `GEMINI_API_KEY=<your Gemini API key>`
 - `ANTHROPIC_API_KEY=<your Anthropic API key>`
 
-For Ollama, create an entry for your host, use the `--host` flag to set a custom host and path (Defaults to `localhost:11434`).
+For Ollama, create an entry for your host, or use `--host` (`-h`) to set a custom host/port (defaults to `localhost:11434`):
 
 - `OLLAMA_HOSTNAME=<the server and port number running Ollama>`
 
-```
-Usage: i18n-ai-translate [options] [command]
+Relative input paths begin from the `jsons/` directory.
 
-Use ChatGPT or Gemini to translate your i18n JSON to any language
+### `translate`
 
-Options:
-  -V, --version        output the version number
-  -h, --help           display help for command
-
-Commands:
-  translate [options]
-  diff [options]
-  help [command]       display help for command
-```
+Converts a local i18n JSON file (or a directory of them) into any target language.
 
 ```
 Usage: i18n-ai-translate translate [options]
@@ -162,144 +124,248 @@ Options:
   -i, --input <input>                         Source i18n file or path of source language, in the jsons/ directory if a relative path is given
   -o, --output-languages [language codes...]  A list of languages to translate to
   -e, --engine <engine>                       Engine to use (chatgpt, gemini, ollama, or claude)
-  -m, --model <model>                         Model to use (e.g. gpt-4o, gemini-2.0-flash-exp, llama3.3, claude-3-5-sonnet-latest)
-  -r, --rate-limit-ms <rateLimitMs>           How many milliseconds between requests (defaults to 1s for Gemini, 120ms (at 500RPM) for ChatGPT, 1200ms
-                                              for Claude)
+  -m, --model <model>                         Model to use (e.g. gpt-5.2, gemini-2.5-flash, llama3.3, claude-sonnet-4-6)
+  -r, --rate-limit-ms <rateLimitMs>           How many milliseconds between requests (defaults to 1s for Gemini, 120ms (500 RPM) for ChatGPT, 1200ms for Claude)
   -f, --force-language-name <language name>   Force output language name
   -A, --all-languages                         Translate to all supported languages
   -p, --templated-string-prefix <prefix>      Prefix for templated strings (default: "{{")
   -s, --templated-string-suffix <suffix>      Suffix for templated strings (default: "}}")
   -k, --api-key <API key>                     API key
-  -h, --host <hostIP:port>                    The host and port number serving Ollama. 11434 is the default port number.
-  --ensure-changed-translation                Each generated translation key must differ from the input (for keys longer than 4) (default: false)
-  -n, --batch-size <batchSize>                How many keys to process at a time (default: "32")
-  --skip-translation-verification             Skip validating the resulting translation through another query (default: false)
-  --skip-styling-verification                 Skip validating the resulting translation's formatting through another query (default: false)
-  --override-prompt <path to JSON file>       Use the prompts from the given JSON file, containing keys for at least one of generationPrompt,
-                                              translationVerificationPrompt, stylingVerificationPrompt
-  --prompt-mode <prompt-mode>                 Chose between 'csv' mode for better performance and 'json' mode for better compatibility,
-  --batch-max-tokens <batch-max-tokens>       For json mode only, maximum size of a single request in tokens
-  --verbose                                   Print logs about progress (default: false)
+  -h, --host <hostIP:port>                    The host and port number serving Ollama (default port 11434)
+  --ensure-changed-translation                Each generated translation key must differ from the input (for keys longer than 4)
+  -n, --batch-size <batchSize>                How many keys to process at a time (32 for ChatGPT, 16 otherwise)
+  --skip-translation-verification             Skip validating the resulting translation through another query
+  --skip-styling-verification                 Skip validating the resulting translation's formatting through another query, only for 'csv' mode
+  --override-prompt <path to JSON file>       Use the prompts from the given JSON file
+  --verbose                                   Print logs about progress
+  --prompt-mode <prompt-mode>                 'csv' (better performance, needs GPT-class) or 'json' (better compatibility, ~50% slower)
+  --batch-max-tokens <batch-max-tokens>       Maximum token size of a single request (JSON mode only)
+  --dry-run                                   Preview translations without writing; outputs go to /tmp
+  --no-continue-on-error                      Abort on first key/batch failure (default: skip failures and report to stderr)
+  --concurrency <concurrency>                 How many batches to run in parallel within one language (default: 2)
+  --context <context>                         Product or domain context to steer translations
+  --exclude-languages [language codes...]     Language codes to skip
+  --tokens-per-minute <tpm>                   Cap tokens-per-minute across all concurrent workers (disabled by default)
+  --language-concurrency <n>                  How many target languages to translate in parallel (default: 1)
   --help                                      display help for command
 ```
+
+#### Examples
+
+```bash
+# Translate to French
+npx i18n-ai-translate translate -i en.json -o fr
+
+# Translate to three languages via Gemini
+npx i18n-ai-translate translate -i en.json -o es de nl --engine gemini
+
+# Translate to every supported language
+npx i18n-ai-translate translate -i en.json -A --engine chatgpt --rate-limit-ms 150 -n 64
+
+# Parallel fan-out: 4 concurrent languages × 4 batches each, with a TPM cap
+npx i18n-ai-translate translate -i en.json -o fr es de it ja zh ko pt ru ar \
+    --language-concurrency 4 --concurrency 4 --tokens-per-minute 150000
+
+# Skip locales you maintain by hand
+npx i18n-ai-translate translate -i en.json -A --exclude-languages fr de
+
+# Domain context for better terminology
+npx i18n-ai-translate translate -i en.json -o ja --context "a music trivia game for Discord"
+
+# Preview without writing
+npx i18n-ai-translate translate -i en.json -o fr --dry-run --verbose
+```
+
+### `diff`
+
+Computes the difference between two versions of a source file (or directory) and applies the diff to every sibling target. **Untouched keys are preserved**, added/modified keys are re-translated, and deleted keys are removed. Each language is written to disk as soon as it finishes so a mid-run crash doesn't discard completed work.
 
 ```
 Usage: i18n-ai-translate diff [options]
 
 Options:
-  -b, --before <fileOrDirectoryBefore>      Source i18n file or directory before changes, in the jsons/ directory if a relative path is given
-  -a, --after <fileOrDirectoryAfter>        Source i18n file or directory after changes, in the jsons/ directory if a relative path is given
-  -l, --input-language <inputLanguageCode>  The input language's code, in ISO6391 (e.g. en, fr)
-  -e, --engine <engine>                     Engine to use (chatgpt, gemini, ollama, or claude)
-  -m, --model <model>                       Model to use (e.g. gpt-4o, gemini-2.0-flash-exp, llama3.3, claude-3-5-sonnet-latest)
-  -r, --rate-limit-ms <rateLimitMs>         How many milliseconds between requests (defaults to 1s for Gemini, 120ms (at 500RPM) for ChatGPT, 1200ms for
-                                            Claude)
+  -b, --before <fileOrDirectoryBefore>      Source i18n file or directory before changes
+  -a, --after <fileOrDirectoryAfter>        Source i18n file or directory after changes
+  -l, --input-language <inputLanguageCode>  The input language's code; ISO-639-1 (e.g. en, fr) or an English name like "English"
+  -e, --engine <engine>                     Engine to use
+  -m, --model <model>                       Model to use
+  -r, --rate-limit-ms <rateLimitMs>         Gap between requests
   -k, --api-key <API key>                   API key
-  -h, --host <hostIP:port>                  The host and port number serving Ollama. 11434 is the default port number.
-  --ensure-changed-translation              Each generated translation key must differ from the input (for keys longer than 4) (default: false)
-  -p, --templated-string-prefix <prefix>    Prefix for templated strings (default: "{{")
-  -s, --templated-string-suffix <suffix>    Suffix for templated strings (default: "}}")
-  -n, --batch-size <batchSize>              How many keys to process at a time (default: "32")
-  --skip-translation-verification           Skip validating the resulting translation through another query (default: false)
-  --skip-styling-verification               Skip validating the resulting translation's formatting through another query (default: false)
-  --override-prompt <path to JSON file>     Use the prompts from the given JSON file, containing keys for at least one of generationPrompt,
-                                            translationVerificationPrompt, stylingVerificationPrompt
-  --prompt-mode <prompt-mode>               Chose between 'csv' mode for better performance and 'json' mode for better compatibility,
-  --batch-max-tokens <batch-max-tokens>     For json mode only, maximum size of a single request in tokens
-  --verbose                                 Print logs about progress (default: false)
+  -h, --host <hostIP:port>                  Ollama host:port
+  --ensure-changed-translation              Force each translation to differ from the source
+  -p, --templated-string-prefix <prefix>    Default "{{"
+  -s, --templated-string-suffix <suffix>    Default "}}"
+  -n, --batch-size <batchSize>              32 for ChatGPT, 16 otherwise
+  --skip-translation-verification           Skip accuracy verify
+  --skip-styling-verification               Skip styling verify (CSV mode only)
+  --override-prompt <path to JSON file>     Custom prompts
+  --verbose                                 Progress logs
+  --prompt-mode <prompt-mode>               'csv' or 'json'
+  --batch-max-tokens <batch-max-tokens>     JSON mode only
+  --dry-run                                 Preview
+  --no-continue-on-error                    Abort on first failure
+  --concurrency <concurrency>               Parallel batches (default: 2)
+  --context <context>                       Domain context
+  --exclude-languages [language codes...]   Locales to skip
+  --tokens-per-minute <tpm>                 TPM cap
   --help                                    display help for command
 ```
 
-### Example usage
+#### Examples
 
-#### `npx i18n-ai-translate translate -i en.json -o fr`
+```bash
+# Apply en changes to every sibling JSON; supports BCP-47 filenames (es-ES, pt-BR, zh-CN)
+npx i18n-ai-translate diff -b en.json -a en-after.json -l en --engine claude
 
-- Translate the `en.json` file in `jsons/` to French, and save the output in `fr.json`
+# Directory diff with verbose logging via Ollama
+npx i18n-ai-translate diff -b en -a en-after --engine ollama --host my-ollama:11434 --verbose
 
-#### `npx i18n-ai-translate translate -i en.json -o es de nl --engine gemini`
+# Domain-aware diff
+npx i18n-ai-translate diff -b en-before.json -a en.json -l en --engine chatgpt \
+    --context "invoicing software for small businesses"
+```
 
-- Translate the `en.json` file in `jsons/` to Spanish, German, and Dutch, and save each file in `jsons/`, using Google Gemini
+### `check`
 
-#### `npx i18n-ai-translate diff -b en.json -a en-after.json -l English --verbose --engine ollama --host my-olllama-server.com:12345`
+Validates already-translated target files against the source without writing anything. Runs the verification-only path of the JSON pipeline and reports per-key issues.
 
-- Translate the keys that have changed between `en.json` and `en-after.json` for all files in the `en.json` directory, with logging enabled using Ollama running on `my-ollama-server.com:12345`
+```
+Usage: i18n-ai-translate check [options]
 
-#### `npx i18n-ai-translate translate -i en.json -A --engine chatgpt --model gpt-4-turbo --api-key <my_key> --rate-limit-ms 150 -n 64`
+Options:
+  -i, --input <input>                         Source i18n file
+  -o, --target-languages [language codes...]  Language codes to check; if omitted, every sibling JSON in the source's directory
+  -e, --engine <engine>                       Engine to use
+  -m, --model <model>                         Model to use
+  -r, --rate-limit-ms <rateLimitMs>           Gap between requests
+  -k, --api-key <API key>                     API key
+  -h, --host <hostIP:port>                    Ollama host:port
+  -p, --templated-string-prefix <prefix>      Default "{{"
+  -s, --templated-string-suffix <suffix>      Default "}}"
+  -n, --batch-size <batchSize>                32 for ChatGPT, 16 otherwise
+  --override-prompt <path to JSON file>       Custom prompts
+  --verbose                                   Progress logs
+  --prompt-mode <prompt-mode>                 'csv' or 'json'
+  --batch-max-tokens <batch-max-tokens>       JSON mode only
+  --concurrency <concurrency>                 Parallel batches
+  --context <context>                         Domain context
+  --tokens-per-minute <tpm>                   TPM cap
+  --format <format>                           'table' (default) or 'json'
+  --help                                      display help for command
+```
 
-- Translate the `en.json` file in `jsons/` to 180+ languages, save each file in `jsons/`, using the GPT-4 Turbo model of ChatGPT, with the given key, a rate limit of 150ms between requests, and 64 keys sent in each batch
+Exit code is non-zero if any issue is reported, so you can gate CI on it.
 
-#### `npx i18n-ai-translate diff -b en -a en-after --engine claude`
+#### Examples
 
-- Translate the keys that have changed between `en/` and `en-after/` for all JSON files in both directories using Claude
+```bash
+# Report on every sibling locale, human-readable output
+npx i18n-ai-translate check -i en.json
 
-#### `npx i18n-ai-translate translate -i en.json -o fr --engine chatgpt --model gpt-4o --api-key <my_key> --dry-run`
-
-- Show what the translation of `en.json` to French would be, but do not actually write the output to disk. A directory is created in `/tmp` with the completed translations and patches to apply to existing translations.
+# JSON output suitable for CI parsing
+npx i18n-ai-translate check -i en.json -o fr de ja --format json > audit.json
+```
 
 ## As a library
 
-Alternatively, import this project and use it to convert JSONs on-the-fly with [`translate()`](https://github.com/taahamahdi/i18n-ai-translate/blob/master/src/interfaces/translation_options.ts), or use [`translateDiff()`](https://github.com/taahamahdi/i18n-ai-translate/blob/master/src/interfaces/translation_diff_options.ts) to fetch updates to modified keys when your source i18n file has changed.
+Import `translate`, `translateDiff`, or `check` to drive the pipelines programmatically. See [`Options`](https://github.com/taahamahdi/i18n-ai-translate/blob/master/src/interfaces/options.ts) for the full shared shape.
 
 ```ts
-import { translate, translateDiff } from "i18n-ai-translate";
+import { translate, translateDiff, check } from "i18n-ai-translate";
 
-...
+const englishJSON = {
+    welcomeMessage: "Welcome, {{name}}!",
+    messages: {
+        notifications_one: "You have one notification",
+        notifications_other: "You have {{count}} notifications",
+        delete: 'Would you like to delete the "{{name}}" category?',
+    },
+};
 
-const translation = await translate({
-    apiKey, // OpenAI/Gemini/Anthropic API key
-    batchMaxTokens, // Maximum amount of tokens for one request
-    batchSize, // How many keys to process at a time
-    chatParams, // Additional configuration to pass to the model
-    engine, // ChatGPT, Gemini, Ollama, or Claude
-    ensureChangedTranslation, // Every key longer than 4 characters must be different than the input
-    host, // The host and port number running Ollama
-    inputJSON, // JSON to translate
-    inputLanguageCode, // Language code of inputJSON (e.g. en, fr, etc.)
-    model, // Model to use (e.g. gpt-4o, gemini-2.0-flash-exp, llama3.3, claude-3-5-sonnet-latest)
-    outputLanguageCode, // Targeted language code (e.g. fr, es, etc.)
-    overridePrompt, // Set custom prompts for generation or verification
-    promptMode, // Chose between 'csv' mode and 'json' mode
-    rateLimitMs, // How many milliseconds between requests
-    skipStylingVerification, // Whether to skip an additional query to see whether the text formatting remained consistent
-    skipTranslationVerification, // Whether to skip an additional query to see whether the resultant translation makes sense
-    templatedStringPrefix, // The start of inline variables; defaults to "{{"
-    templatedStringSuffix, // The end of inline variables; defaults to "}}"
-    verbose, // Print status of conversion to stdout/stderr
-    dryRun, // Whether to write the output to disk
+const frenchTranslation = await translate({
+    apiKey: process.env.OPENAI_API_KEY,
+    engine: "chatgpt",
+    model: "gpt-5.2",
+    inputJSON: englishJSON,
+    inputLanguageCode: "en",
+    outputLanguageCode: "fr",
+    // All optional:
+    context: "a music trivia game for Discord",
+    concurrency: 4,
+    tokensPerMinute: 150_000,
+    continueOnError: true,
+    promptMode: "json",
 });
 
-const translations = await translateDiff({
-    apiKey, // OpenAI/Gemini/Anthropic API key
-    batchMaxTokens, // Maximum amount of tokens for one request
-    batchSize, // How many keys to process at a time
-    chatParams, // Additional configuration to pass to the model
-    engine, // ChatGPT, Gemini, Ollama, or Claude
-    ensureChangedTranslation, // Every key longer than 4 characters must be different than the input
-    host, // The host and port number running Ollama
-    inputJSONAfter, // The source translation after a change
-    inputJSONBefore, // The source translation before a change
-    inputLanguageCode, // Language of inputJSONBefore/After
-    model, // Model to use (e.g. gpt-4o, gemini-2.0-flash-exp, llama3.3, claude-3-5-sonnet-latest)
-    overridePrompt, // Set custom prompts for generation or verification
-    promptMode, // Chose between 'csv' mode and 'json' mode
-    rateLimitMs, // How many milliseconds between requests
-    skipStylingVerification, // Whether to skip an additional query to see whether the text formatting remained consistent
-    skipTranslationVerification, // Whether to skip an additional query to see whether the resultant translation makes sense
-    templatedStringPrefix, // The start of inline variables; defaults to "{{"
-    templatedStringSuffix, // The end of inline variables; defaults to "}}"
-    toUpdateJSONs, // An object of language codes to their translations
-    verbose, // Print status of conversion to stdout/stderr
-    dryRun, // Whether to write the output to disk
+// Re-translate only changed keys across all sibling locales:
+const diffed = await translateDiff({
+    apiKey: process.env.ANTHROPIC_API_KEY,
+    engine: "claude",
+    model: "claude-sonnet-4-6",
+    inputJSONBefore: require("./en-before.json"),
+    inputJSONAfter: require("./en.json"),
+    inputLanguageCode: "en",
+    toUpdateJSONs: {
+        fr: require("./fr.json"),
+        de: require("./de.json"),
+    },
+    onLanguageComplete: (languageCode, translated) => {
+        // Persist each language as soon as it finishes so a late crash
+        // doesn't discard completed work.
+        fs.writeFileSync(`./${languageCode}.json`, JSON.stringify(translated, null, 2));
+    },
 });
+
+// Audit existing translations without writing
+const report = await check({
+    apiKey: process.env.OPENAI_API_KEY,
+    engine: "chatgpt",
+    model: "gpt-5.2",
+    inputJSON: require("./en.json"),
+    targetJSON: require("./fr.json"),
+    inputLanguageCode: "en",
+    outputLanguageCode: "fr",
+});
+// report.issues = [{ key, original, translated, issue, suggestion }]
+if (report.issues.length > 0) {
+    console.error("Translation drift detected:", report.issues);
+    process.exit(1);
+}
 ```
 
-## CSV Mode
+# Concurrency & rate limits
 
-### Translation prompt
+Two concurrency dials, one shared budget:
 
-Batches of the i18n input are passed in. Each call is checked to ensure no keys are lost, all templated strings are retained, and no translations were skipped.
+- **`--concurrency <n>`** (default 2) — batches run in parallel within a single language. Each worker holds its own chat history.
+- **`--language-concurrency <n>`** (default 1) — target languages run in parallel. All languages share one `ChatPool` and one `RateLimiter`, so raising this does **not** multiply provider traffic.
+
+The shared `RateLimiter` enforces:
+
+- Per-request RPM via `--rate-limit-ms` (engine-specific default).
+- Per-minute TPM via `--tokens-per-minute` (off by default; opt in using your provider's published tier limit).
+- Automatic back-off across all workers when any worker receives a 429 (exponential with `Retry-After` honored).
+
+**Suggested tunings:**
+
+| Tier                           | `--concurrency` | `--language-concurrency` | `--tokens-per-minute` |
+| ------------------------------ | --------------- | ------------------------ | --------------------- |
+| Free / evaluation              | 1               | 1                        | 10000                 |
+| OpenAI Tier-1                  | 4               | 4                        | 150000                |
+| Anthropic Tier-1               | 2               | 2                        | 30000                 |
+| Self-hosted Ollama             | 4-8             | 2-4                      | off                   |
+
+# Prompt reference
+
+All prompts are defined in English regardless of target language — this is intentional and research-backed (English scaffolding steers models more reliably than localized scaffolding). Expand ISO codes to language names before interpolation.
+
+### CSV translation prompt
+
+Batches of the input are passed in. Each output line is expected to be wrapped in ASCII quotes.
 
 ```
+Product context: ${context}           ← only included when --context is supplied
+
 You are a professional translator.
 
 Translate each line from ${inputLanguage} to ${outputLanguage}.
@@ -312,54 +378,42 @@ Output only the translations.
 
 All lines should start and end with an ASCII quotation mark (").
 
-\`\`\`
+```
 ${input}
-\`\`\`
+```
 ```
 
-### Translation verification prompt
+### CSV verification prompt
 
-The output of the translation is sent back to ensure the model is okay with the translation. If this fails, the translation is re-generated.
+The previous two-prompt chain (accuracy + styling) has been merged into a single rubric that flags NAK on any translation issue. The standalone styling prompt is only invoked when the user has supplied a `stylingVerificationPrompt` override, which saves a round-trip in the default case.
 
 ```
-Given a translation from ${inputLanguage} to ${outputLanguage} in CSV form, reply with NAK if _any_ of the translations are poorly translated.
+Product context: ${context}
+
+You are a translation reviewer checking a ${inputLanguage}-to-${outputLanguage} batch in CSV form.
+
+Reply with NAK if ANY translation has a problem, including:
+- Inaccurate meaning, wrong tone, or grammar errors
+- Mismatched capitalization, punctuation, or whitespace vs. the original
+- Missing or extra placeholders, or altered variable names
 
 Otherwise, reply with ACK.
 
-Only reply with ACK/NAK.
+Reply with ACK or NAK only — no explanation.
 
-\`\`\`
+```
 ${inputLanguage},${outputLanguage}
 ${mergedCSV}
-\`\`\`
+```
 ```
 
-### Styling verification prompt
+### JSON translation prompt
 
-Formatting from the input should be retained where possible. If punctuation, capitalization, or whitespaces differ between the source and the translation, the translation is re-generated.
-
-```
-Given text from ${inputLanguage} to ${outputLanguage} in CSV form, reply with NAK if _any_ of the translations do not match the formatting of the original.
-
-Check for differing capitalization, punctuation, or whitespaces.
-
-Otherwise, reply with ACK.
-
-Only reply with ACK/NAK.
-
-\`\`\`
-${inputLanguage},${outputLanguage}
-${mergedCSV}
-\`\`\`
-```
-
-## JSON Mode
-
-### Translation prompt
-
-Batches of the i18n input are passed in. Each call is checked to ensure no keys are lost, all templated strings are retained, and no translations are skipped.
+Batches use structured-output validation via Zod schemas.
 
 ```
+Product context: ${context}
+
 You are a professional translator.
 
 Translate from ${inputLanguage} to ${outputLanguage}.
@@ -368,26 +422,28 @@ Translate from ${inputLanguage} to ${outputLanguage}.
 - 'original' is the text to be translated.
 - 'translated' must not be empty.
 - 'context' is additional info if needed.
-- 'failure' explains why the previous translation failed.
-- Preserve text formatting, case sensitivity, and whitespace.
+- 'failure' explains why the previous translation failed; use it to avoid repeating the same mistake.
+- Preserve text formatting, case sensitivity, and whitespace. UI strings should stay close to the source length where possible.
 
 Special Instructions:
-- Treat anything in the format {{variableName}} as a placeholder. Never translate or modify its content.
-- Do not add your own variables
-- The number of variables like {{timeLeft}} must be the same in the translated text.
-- Do not convert {{NEWLINE}} to \\n.
+- Treat anything in the format {{variableName}} as a placeholder. Never translate or modify its content. Do not convert {{NEWLINE}} to \n.
+- Do not add variables that are not in the original.
+- The number of variables must be the same in the translated text.
+- Some keys end in CLDR plural suffixes (_zero, _one, _two, _few, _many, _other)...  ← only when plural keys are detected
 
 Return the translation as JSON.
-\`\`\`json
+```json
 ${input}
-\`\`\`
+```
 ```
 
-### Translation verification prompt
+### JSON verification prompt
 
-The output of the translation is sent back to ensure the model is okay with the translation/formatting. If this fails, the translation is re-generated.
+Per-item verify with a schema returning `{ valid, issue, fixedTranslation }`. The prompt explicitly asks the model not to revise correct translations (a common failure mode).
 
 ```
+Product context: ${context}
+
 You are a professional translator.
 
 Check translations from ${inputLanguage} to ${outputLanguage}.
@@ -396,31 +452,34 @@ Check translations from ${inputLanguage} to ${outputLanguage}.
 - 'original' is the text to be translated.
 - 'translated' is the translated text.
 - 'context' is additional info if needed.
-- 'failure' explains why the previous translation failed.
-- check for Accuracy (meaning, tone, grammar), Formatting (case, whitespace, punctuation).
+- 'failure' explains why a prior translation failed; only populated during re-verification.
+- Check for accuracy (meaning, tone, grammar) and formatting (case, whitespace, punctuation).
 
-If correct, return 'valid' as 'true' and leave 'fixedTranslation' and 'issue' empty.
-If incorrect, return 'valid' as 'false' and put the fixed translation in 'fixedTranslation' and explain what is 'issue'.
+Do not revise correct translations. Flag only issues that meaningfully affect accuracy or readability.
+If the translation is correct, return 'valid' as 'true' and leave 'fixedTranslation' and 'issue' empty.
+If the translation is incorrect, return 'valid' as 'false', put the corrected translation in 'fixedTranslation', and explain the problem in 'issue'.
 
 Special Instructions:
-- Treat anything in the format {{variableName}} as a placeholder. Never translate or modify its content.
-- Do not add your own variables
-- The number of variables like {{timeLeft}} must be the same in the translated text.
-- Do not convert {{NEWLINE}} to \\n.
+- Treat anything in the format {{variableName}} as a placeholder. Never translate or modify its content. Do not convert {{NEWLINE}} to \n.
+- Do not add variables that are not in the original.
+- The number of variables must be the same in the translated text.
 
-Allow minor grammar, phrasing, and formatting differences if meaning is clear.
-Flag only significant issues affecting accuracy or readability.
-
-Return the verified as JSON.
-\`\`\`json
+Return the verified output as JSON.
+```json
 ${input}
-\`\`\`
+```
 ```
 
 ## Prompt overriding
 
-Replace the aforementioned prompts with your own by creating a JSON file containing keys of at least one of `generationPrompt`, `translationVerificationPrompt`, or `stylingVerificationPrompt` (only used in CSV mode). Then, pass it as an argument with `--override-prompt <path to file>`. Be sure to include templated arguments like `${inputLanguage}` as part of the prompt.
+Replace any built-in prompt with your own by creating a JSON file containing one or more of:
+
+- `generationPrompt` — replaces the translation prompt for both CSV and JSON mode
+- `translationVerificationPrompt` — replaces the verification prompt (CSV or JSON)
+- `stylingVerificationPrompt` — CSV mode only; when supplied, re-enables the standalone styling pass
+
+Pass the file path with `--override-prompt <path>`. Use `${inputLanguage}`, `${outputLanguage}`, `${context}`, and `${input}` (or `${mergedCSV}` for the CSV verification prompts) as template placeholders. Missing required placeholders throw at startup.
 
 ## Dry-run mode
 
-Add the `--dry-run` flag to see what the translation would be without actually writing any files. A directory is created in `/tmp` with the completed translations and patches to apply to existing translations.
+Add the `--dry-run` flag on `translate` or `diff` to preview without writing. A directory is created in `/tmp/i18n-ai-translate-<timestamp>` with the full proposed output plus a `.patch` showing the diff against the existing file.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # i18n‑ai‑translate
 
-AI‑powered localization for your **i18next‑style** JSON files. Automate translating of single files or entire directories with ChatGPT, Gemini, Claude, or local Ollama models -- while keeping accurate translations, formatting consistent, and intact `{{variables}}`.
+AI‑powered localization for your **i18next‑style** JSON files. Automate translating single files or entire directories with ChatGPT, Gemini, Claude, or local Ollama models — while keeping translations accurate, formatting consistent, and `{{variables}}` intact.
 
 _For a detailed walkthrough and advanced tips, see [ADVANCED_GUIDE.md](ADVANCED_GUIDE.md)._
 
@@ -8,44 +8,66 @@ _For a detailed walkthrough and advanced tips, see [ADVANCED_GUIDE.md](ADVANCED_
 
 ## Why use it?
 
-| Feature               | What it means                                               |
-| --------------------- | ----------------------------------------------------------- |
-| **Multi‑engine**      | Choose OpenAI, Google, Anthropic, or your own Ollama models |
-| **Safe translations** | Dual verification checks accuracy **and** formatting        |
-| **Diff‑aware**        | Only re‑translate keys you changed                          |
-| **Everywhere**        | Use as a CLI, GitHub Action, or Node library                |
-| **Dry‑run**           | Preview updates before touching disk                        |
+| Feature               | What it means                                                                           |
+| --------------------- | --------------------------------------------------------------------------------------- |
+| **Multi‑engine**      | Choose OpenAI, Google, Anthropic, or your own Ollama models                             |
+| **Fast**              | Parallel per-batch workers share one rate limiter; translate 20 locales concurrently    |
+| **Safe**              | Translations verified against the source before being written                           |
+| **Diff‑aware**        | Only re‑translate keys you changed; existing translations are preserved                 |
+| **Check mode**        | Audit existing translations for drift, missing placeholders, or quality regressions     |
+| **Context-aware**     | `--context` flag injects product info so the model picks domain-appropriate terminology |
+| **Dry‑run**           | Preview updates before touching disk                                                    |
+| **Everywhere**        | Use as a CLI, GitHub Action, or Node library                                            |
 
 ---
 
 ## Quick start
 
-### 1 · Install
+### 1 · Install
 
 ```bash
 npm i -g i18n-ai-translate    # or yarn add i18n-ai-translate --dev
 export OPENAI_API_KEY=•••     # or GEMINI_API_KEY / ANTHROPIC_API_KEY
 ```
 
-### 2 · Translate a file
+### 2 · Translate a file
 
 ```bash
 i18n-ai-translate translate -i i18n/en.json -o fr \
-  -e chatgpt -m gpt-4o
+  -e chatgpt -m gpt-5.2
 ```
 
-Need more languages? Pass multiple codes (`-o fr es de`) or `-A` for **all** 180+.
+Need more languages? Pass multiple codes (`-o fr es de`) or `-A` for **all** 180+. Filenames like `es-ES.json` / `pt-BR.json` are accepted too — the language subtag is extracted automatically. Skip specific locales with `--exclude-languages fr de` (handy for locales you maintain by hand).
 
-### 3 · Translate a folder
+### 3 · Translate a folder
 
 ```bash
 i18n-ai-translate translate -i i18n/en -o fr es de \
-  -e chatgpt -m gpt-4o
+  -e chatgpt -m gpt-5.2
 ```
 
-This recursively translates all `*.json` files in `en` and writes to `i18n/fr`, `i18n/es`, and `i18n/de`.
+Recursively translates every `*.json` file in `en` and writes the results to `i18n/fr`, `i18n/es`, and `i18n/de`.
 
-### 4 · Keep PRs up‑to‑date
+### 4 · Translate only what changed
+
+```bash
+i18n-ai-translate diff \
+  -b i18n/en-before.json -a i18n/en.json \
+  -l en -e claude -m claude-sonnet-4-6
+```
+
+Preserves every existing translation; only added/modified keys are re-translated, only deleted keys are removed. Per-locale writes are persisted as each language finishes, so a mid-run crash doesn't discard completed work.
+
+### 5 · Check an existing translation
+
+```bash
+i18n-ai-translate check -i i18n/en.json -o fr de \
+  -e chatgpt -m gpt-5.2 --format json
+```
+
+Runs the verification pipeline against your existing translations without writing anything. Emits a structured report of keys the model flagged. Exits non-zero if any issue is found, so you can gate CI on it.
+
+### 6 · Keep PRs up‑to‑date
 
 Add a one‑liner GitHub Action to auto‑translate whenever `en.json` changes:
 
@@ -61,48 +83,66 @@ Add a one‑liner GitHub Action to auto‑translate whenever `en.json` changes:
 ## CLI cheat‑sheet
 
 ```bash
-# Translate a file or folder
-translate   -i <src>      -o <lang…>   [options]
-
-# Re‑translate only edited keys
-diff        -b <before>   -a <after>   [options]
-
-# See all flags
---help
+translate  -i <src>      -o <lang…>   [options]   # Translate a file or folder
+diff       -b <before>   -a <after>   [options]   # Re‑translate only edited keys
+check      -i <src>      -o <lang…>   [options]   # Verify existing translations (no writes)
 ```
 
-Common flags:
+Common flags (all subcommands accept these unless noted):
 
-| Flag                  | Default         | Description                                         |
-| --------------------- | --------------- | --------------------------------------------------- |
-| `-e, --engine`        | chatgpt         | chatgpt · gemini · claude · ollama                  |
-| `-m, --model`         | gpt-5.2         | e.g. gemini‑2.5‑flash, claude‑sonnet‑4‑6            |
-| `-r, --rate-limit-ms` | engine‑specific | Gap between requests                                |
-| `--dry-run`           | false           | Don’t write files, preview instead                  |
+| Flag                      | Default         | Description                                                                     |
+| ------------------------- | --------------- | ------------------------------------------------------------------------------- |
+| `-e, --engine`            | chatgpt         | chatgpt · gemini · claude · ollama                                              |
+| `-m, --model`             | gpt‑5.2         | e.g. `gemini‑2.5‑flash`, `claude‑sonnet‑4‑6`, `llama3.3`                        |
+| `-l, --input-language`    | from filename   | ISO‑639‑1 code or English name (`en`, `French`) — BCP‑47 tags like `pt-BR` OK   |
+| `-r, --rate-limit-ms`     | engine‑specific | Minimum gap between requests                                                    |
+| `--concurrency`           | 2               | Batches to run in parallel within one language                                  |
+| `--language-concurrency`  | 1               | Target languages to translate in parallel (shares pool + rate limit)            |
+| `--tokens-per-minute`     | off             | Extra TPM cap across all workers; pair with `--concurrency` to stay under tier  |
+| `--context <string>`      | —               | Product/domain context, e.g. `"a B2B invoicing SaaS"`                           |
+| `--exclude-languages`     | —               | Locales to skip (for manually‑maintained targets)                               |
+| `--no-continue-on-error`  | continue        | Abort on first key/batch failure instead of skipping                            |
+| `--dry-run`               | false           | Don't write files, preview instead (translate/diff only)                        |
+| `--format`                | table           | `table` or `json` report output (check only)                                    |
 
-Full flag list: `i18n-ai-translate translate --help`.
+Full flag list: `i18n-ai-translate <subcommand> --help`.
 
 ---
 
 ## Use as a library
 
 ```ts
-import { translate } from "i18n-ai-translate";
+import { translate, translateDiff, check } from "i18n-ai-translate";
 
 const fr = await translate({
   inputJSON: require("./en.json"),
-  inputLanguage: "en",
-  outputLanguage: "fr",
+  inputLanguageCode: "en",
+  outputLanguageCode: "fr",
   engine: "chatgpt",
-  model: "gpt-4o",
+  model: "gpt-5.2",
+  apiKey: process.env.OPENAI_API_KEY,
+  context: "a music trivia game for Discord", // optional
+  concurrency: 4,                             // optional
+});
+
+const report = await check({
+  inputJSON: require("./en.json"),
+  targetJSON: require("./fr.json"),
+  inputLanguageCode: "en",
+  outputLanguageCode: "fr",
+  engine: "chatgpt",
+  model: "gpt-5.2",
   apiKey: process.env.OPENAI_API_KEY,
 });
+// report.issues = [{ key, original, translated, issue, suggestion }]
 ```
 
 ---
 
 ## Advanced topics
 
-* **Prompt modes**: `csv` (faster) vs `json` (maximum fidelity)
-* **Custom prompts**: swap in your own generation / verification prompts
-* **Placeholders**: keep `{{prefix}}` & `{{suffix}}` exactly as‑is
+* **Prompt modes**: `csv` (faster, GPT‑class models only) vs `json` (structured output, works with weaker models too)
+* **Custom prompts**: swap in your own generation/verification prompts via `--override-prompt`
+* **Plural awareness**: keys ending in `_one`/`_other`/`_few`/`_many` get a CLDR plural hint in JSON mode
+* **Placeholders**: `{{variables}}` are preserved; customise delimiters with `-p`/`-s`
+* **Rate-limit handling**: per-engine defaults + exponential backoff; `--tokens-per-minute` adds TPM cap

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "zod-to-json-schema": "^3.24.1"
   },
   "name": "i18n-ai-translate",
-  "version": "4.1.2",
+  "version": "5.0.0",
   "main": "./build/index.js",
   "types": "./build/types/index.d.ts",
   "bin": {


### PR DESCRIPTION
Docs were stale on every major feature that landed over the past several PRs. This refresh covers:

- `check` subcommand (#471)
- `--context` for domain-aware prompts (#470)
- `--exclude-languages` (#472)
- `--concurrency` / `--language-concurrency` for parallel fan-out
- `--tokens-per-minute` TPM cap
- `--no-continue-on-error` (default: continue)
- BCP-47 locale filenames (es-ES.json, pt-BR.json)
- Full English language names (`-l English`) accepted
- Current default models (gpt-5.2, claude-sonnet-4-6)
- Merged CSV verification prompt (accuracy + styling in one pass)
- CLDR plural-suffix awareness in JSON mode
- Cross-worker rate limiter with exponential backoff and Retry-After

README gains a quick-start entry for `check` and updates the flag cheat-sheet. ADVANCED_GUIDE gains a dedicated "Concurrency & rate limits" section with a per-tier tuning table, updated prompt reference that reflects the current English-language scaffolding, and worked examples that use modern flag combinations.

Version bumped to 5.0.0 — the behavioural changes (diff no longer wiping unchanged keys; parallelism by default; RateLimiter.acquire() signature; CSV verification merge affecting --override-prompt shape; new `check` surface) are collectively a breaking-semver change. The VERSION constant reads from package.json so it picks up automatically.