### PR TITLE
Add pluggable file-format adapters with Gettext PO support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ i18n-ai-translate translate -i i18n/en.json -o fr \
 
 Need more languages? Pass multiple codes (`-o fr es de`) or `-A` for **all** 180+. Filenames like `es-ES.json` / `pt-BR.json` are accepted too — the language subtag is extracted automatically. Skip specific locales with `--exclude-languages fr de` (handy for locales you maintain by hand).
 
+**Other formats:** Gettext `.po` files work too — the format is inferred from the file extension (override with `--file-format json|po`). Comments, `msgctxt`, plural forms, and `printf` placeholders round-trip losslessly. Works across `translate` (file + folder) and `diff`.
+
 ### 3 · Translate a folder
 
 ```bash
@@ -103,6 +105,7 @@ Common flags (all subcommands accept these unless noted):
 | `--exclude-languages`     | —               | Locales to skip (for manually‑maintained targets)                               |
 | `--no-continue-on-error`  | continue        | Abort on first key/batch failure instead of skipping                            |
 | `--dry-run`               | false           | Don't write files, preview instead (translate/diff only)                        |
+| `--file-format`           | from extension  | Input/output file format: `json` or `po` (translate/diff only)                  |
 | `--format`                | table           | `table` or `json` report output (check only)                                    |
 
 Full flag list: `i18n-ai-translate <subcommand> --help`.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "fastest-levenshtein": "^1.0.16",
     "flat": "5.0.2",
     "gemini-zod": "^0.1.2",
+    "gettext-parser": "7.0.1",
     "iso-639-1": "^3.1.0",
     "js-tiktoken": "^1.0.21",
     "ollama": "^0.5.12",
@@ -28,6 +29,7 @@
     "i18n-ai-translate": "./build/i18n-ai-translate.js"
   },
   "devDependencies": {
+    "@types/gettext-parser": "^9.0.0",
     "@types/jest": "^30.0.0",
     "@typescript-eslint/eslint-plugin": "^7.15.0",
     "@typescript-eslint/parser": "^7.15.0",

--- a/src/cli_diff.ts
+++ b/src/cli_diff.ts
@@ -80,6 +80,7 @@ export default function buildDiffCommand(): Command {
             CLI_HELP.ExcludeLanguages,
         )
         .option("--tokens-per-minute <tpm>", CLI_HELP.TokensPerMinute)
+        .option("--file-format <format>", CLI_HELP.FileFormat)
         .action(async (options: any) => {
             const modelArgs = processModelArgs(options);
 
@@ -110,6 +111,7 @@ export default function buildDiffCommand(): Command {
                 continueOnError: options.continueOnError,
                 ensureChangedTranslation: options.ensureChangedTranslation,
                 excludeLanguages: options.excludeLanguages,
+                format: options.fileFormat,
                 pool: sharedPool,
                 rateLimiter: sharedRateLimiter,
                 skipStylingVerification: options.skipStylingVerification,

--- a/src/cli_translate.ts
+++ b/src/cli_translate.ts
@@ -91,7 +91,7 @@ export default function buildTranslateCommand(): Command {
         )
         .option("--tokens-per-minute <tpm>", CLI_HELP.TokensPerMinute)
         .option("--language-concurrency <n>", CLI_HELP.LanguageConcurrency)
-        .option("--format <format>", CLI_HELP.Format)
+        .option("--file-format <format>", CLI_HELP.FileFormat)
         .action(async (options: any) => {
             const modelArgs = processModelArgs(options);
             const languageConcurrency = Math.max(
@@ -128,7 +128,7 @@ export default function buildTranslateCommand(): Command {
                 continueOnError: options.continueOnError,
                 ensureChangedTranslation: options.ensureChangedTranslation,
                 excludeLanguages: options.excludeLanguages,
-                format: options.format,
+                format: options.fileFormat,
                 pool: sharedPool,
                 rateLimiter: sharedRateLimiter,
                 skipStylingVerification: options.skipStylingVerification,

--- a/src/cli_translate.ts
+++ b/src/cli_translate.ts
@@ -91,6 +91,7 @@ export default function buildTranslateCommand(): Command {
         )
         .option("--tokens-per-minute <tpm>", CLI_HELP.TokensPerMinute)
         .option("--language-concurrency <n>", CLI_HELP.LanguageConcurrency)
+        .option("--format <format>", CLI_HELP.Format)
         .action(async (options: any) => {
             const modelArgs = processModelArgs(options);
             const languageConcurrency = Math.max(
@@ -127,6 +128,7 @@ export default function buildTranslateCommand(): Command {
                 continueOnError: options.continueOnError,
                 ensureChangedTranslation: options.ensureChangedTranslation,
                 excludeLanguages: options.excludeLanguages,
+                format: options.format,
                 pool: sharedPool,
                 rateLimiter: sharedRateLimiter,
                 skipStylingVerification: options.skipStylingVerification,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,18 +28,16 @@ export const CLI_HELP = {
         "How many batches to run in parallel (default: 2). Each worker holds its own chat history, sharing one rate limiter. Tune upward together with --rate-limit-ms to use more of your API tier",
     Context:
         "Product or domain context to steer translations (e.g. 'a music trivia game for Discord'). Injected into both the generation and verification prompts",
-    ExcludeLanguages:
-        "Language codes to skip (e.g. 'fr de'). Useful when some locales are maintained manually and shouldn't be machine-translated over",
-    TokensPerMinute:
-        "Cap on tokens-per-minute across all concurrent workers. Disabled by default — opt in with your provider's TPM limit to avoid burst-failing when your TPM tier is stricter than your RPM tier. Reference values: OpenAI Tier-1 ~200000, Anthropic Tier-1 40000 (free 20000), Gemini 2.5 Flash paid ~250000.",
-    LanguageConcurrency:
-        "How many target languages to translate in parallel (default 1). Each language shares the same pool and rate limiter, so raising this does not multiply provider traffic — pair with --concurrency and --tokens-per-minute to tune overall throughput.",
     DryRun: "Show the translations without writing to files, and store them in a temporary directory",
     Engine: "Engine to use (chatgpt, gemini, ollama, or claude)",
     EnsureChangedTranslation:
         "Each generated translation key must differ from the input (for keys longer than 4)",
-    Format:
-        "File format adapter to use (default: inferred from extension). Supported: json, po.",
+    ExcludeLanguages:
+        "Language codes to skip (e.g. 'fr de'). Useful when some locales are maintained manually and shouldn't be machine-translated over",
+    FileFormat:
+        "Input/output file format (default: inferred from extension). Supported: json, po.",
+    LanguageConcurrency:
+        "How many target languages to translate in parallel (default 1). Each language shares the same pool and rate limiter, so raising this does not multiply provider traffic — pair with --concurrency and --tokens-per-minute to tune overall throughput.",
     MaxTokens: "The maximum token size of a request",
     Model: `Model to use (e.g. ${Object.values(DEFAULT_MODEL).join(", ")})`,
     NoContinueOnError:
@@ -55,5 +53,7 @@ export const CLI_HELP = {
         "Skip validating the resulting translation's formatting through another query, only for 'csv' mode",
     SkipTranslationVerification:
         "Skip validating the resulting translation through another query",
+    TokensPerMinute:
+        "Cap on tokens-per-minute across all concurrent workers. Disabled by default — opt in with your provider's TPM limit to avoid burst-failing when your TPM tier is stricter than your RPM tier. Reference values: OpenAI Tier-1 ~200000, Anthropic Tier-1 40000 (free 20000), Gemini 2.5 Flash paid ~250000.",
     Verbose: "Print logs about progress",
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,6 +38,8 @@ export const CLI_HELP = {
     Engine: "Engine to use (chatgpt, gemini, ollama, or claude)",
     EnsureChangedTranslation:
         "Each generated translation key must differ from the input (for keys longer than 4)",
+    Format:
+        "File format adapter to use (default: inferred from extension). Supported: json, po.",
     MaxTokens: "The maximum token size of a request",
     Model: `Model to use (e.g. ${Object.values(DEFAULT_MODEL).join(", ")})`,
     NoContinueOnError:

--- a/src/formats/format_adapter.ts
+++ b/src/formats/format_adapter.ts
@@ -22,6 +22,27 @@ export default interface FormatAdapter<TSidecar = unknown> {
 
     read(raw: string): { flat: Record<string, string>; sidecar: TSidecar };
 
+    /**
+     * Optional second read path for diff mode, where the file is an
+     * existing *target* translation rather than a source. Formats that
+     * store source and target text in the same slot (e.g. JSON, where a
+     * key maps to its value regardless of language) don't need this —
+     * callers fall back to `read`. Formats that separate them (e.g.
+     * Gettext PO: source in `msgid`, target in `msgstr`) implement it so
+     * already-translated values survive a diff.
+     *
+     * The returned flat map is keyed identically to `read` so unchanged
+     * source keys line up; the sidecar is unused on the write side of a
+     * diff (which rebuilds from the source catalogue) but returned for
+     * interface symmetry.
+     * @param raw - the existing target file's contents
+     * @returns the flat map of existing translated values and a sidecar
+     */
+    readTranslated?(raw: string): {
+        flat: Record<string, string>;
+        sidecar: TSidecar;
+    };
+
     write(
         translated: Record<string, string>,
         sidecar: TSidecar,

--- a/src/formats/format_adapter.ts
+++ b/src/formats/format_adapter.ts
@@ -1,0 +1,31 @@
+/**
+ * A format adapter translates between the on-disk file format and the
+ * pipeline's flat `Record<string, string>` contract.
+ *
+ * `read` returns the flat map plus an opaque, format-specific
+ * `sidecar` that carries everything the pipeline doesn't need to see
+ * (comments, metadata, ordering, plural counts, original placeholder
+ * syntax). `write` takes the translated flat map together with the
+ * `sidecar` returned by `read` to reconstruct the output file — so
+ * unchanged keys round-trip byte-for-byte.
+ *
+ * The `TSidecar` generic lets each adapter keep a precise type
+ * internally; the registry erases it at its boundary so callers can
+ * hold a heterogeneous list of adapters without unsafe casts.
+ */
+export default interface FormatAdapter<TSidecar = unknown> {
+    /** Human-readable name; matches `--format <name>` on the CLI. */
+    readonly name: string;
+
+    /** File extensions this adapter claims (leading dot, e.g. `.json`). */
+    readonly extensions: readonly string[];
+
+    read(raw: string): { flat: Record<string, string>; sidecar: TSidecar };
+
+    write(
+        translated: Record<string, string>,
+        sidecar: TSidecar,
+        inputLanguageCode: string,
+        outputLanguageCode: string,
+    ): string;
+}

--- a/src/formats/json_adapter.ts
+++ b/src/formats/json_adapter.ts
@@ -1,0 +1,42 @@
+import { FLATTEN_DELIMITER } from "../constants";
+import { flatten, unflatten } from "flat";
+import type FormatAdapter from "./format_adapter";
+
+/**
+ * Sidecar kept around purely so the original nested shape can be
+ * rebuilt byte-identically on write even if the translation pipeline
+ * adds, drops, or renames leaves. For today's i18next flow we only
+ * need a marker that the file was JSON; kept as an object so future
+ * additions (e.g. preserved ordering, indent width) don't widen the
+ * public adapter interface.
+ */
+type JSONSidecar = {
+    kind: "json";
+};
+
+const JSONAdapter: FormatAdapter<JSONSidecar> = {
+    extensions: [".json"] as const,
+    name: "json",
+
+    read(raw: string): { flat: Record<string, string>; sidecar: JSONSidecar } {
+        const parsed = JSON.parse(raw);
+        const flat = flatten(parsed, {
+            delimiter: FLATTEN_DELIMITER,
+        }) as Record<string, string>;
+
+        return { flat, sidecar: { kind: "json" } };
+    },
+
+    write(translated: Record<string, string>): string {
+        const unflattened = unflatten(translated, {
+            delimiter: FLATTEN_DELIMITER,
+        });
+
+        // Matches the historical `JSON.stringify(..., null, 4) + "\n"`
+        // shape from translate_file.ts — any change here becomes a
+        // diff in every user's output.
+        return `${JSON.stringify(unflattened, null, 4)}\n`;
+    },
+};
+
+export default JSONAdapter;

--- a/src/formats/po_adapter.ts
+++ b/src/formats/po_adapter.ts
@@ -1,0 +1,289 @@
+import { DEFAULT_RULE, getPluralRule } from "./po_plural_rules";
+import { po } from "gettext-parser";
+import type { GetTextComment, GetTextTranslations } from "gettext-parser";
+import type FormatAdapter from "./format_adapter";
+
+/**
+ * ASCII Record Separator — used to join msgctxt, msgid, and optional
+ * plural-suffix segments into a single flat key. Chosen for the same
+ * reason `DIRECTORY_KEY_DELIMITER` was picked elsewhere: no legal PO
+ * content can contain a control character, so round-trip is unambiguous.
+ */
+const KEY_DELIMITER = "\x1e";
+
+/**
+ * printf-style placeholder: `%s`, `%d`, `%1$s`, `%2$.2f`, … Capture
+ * groups: (1) optional `N$` positional index.
+ *
+ * Deliberately tolerant — the adapter's contract is "whatever we strip
+ * on read, we restore on write"; we don't need to fully validate the
+ * printf spec.
+ */
+const PRINTF_REGEX =
+    /%(?:(\d+)\$)?[-+ #0]*\d*(?:\.\d+)?(?:hh|h|ll|l|j|z|t|L)?[sdifFeEgGxXoucpn%]/g;
+
+type PlaceholderMap = {
+    /** Ordered list of native tokens, one per arg slot. */
+    tokens: string[];
+    /** Whether the entry used positional (`%1$s`) or bare (`%s`) tokens. */
+    positional: boolean;
+};
+
+type POEntryMeta = {
+    msgctxt?: string;
+    msgid: string;
+    isPlural: boolean;
+    /** Original comments; preserved on write. */
+    comments?: GetTextComment;
+    placeholders?: PlaceholderMap;
+};
+
+/**
+ * Everything we need to reconstruct the PO file after the flat map
+ * round-trips through the pipeline. The parsed table is kept so header
+ * fields, ordering, obsolete entries, and unreferenced comments all
+ * survive a write.
+ */
+type POSidecar = {
+    kind: "po";
+    parsed: GetTextTranslations;
+    /** Keyed by the same flat key used by the pipeline. */
+    metaByKey: Record<string, POEntryMeta>;
+    /** Source language's plural category list, captured at read time. */
+    sourceCategories: readonly string[];
+};
+
+function makeKey(
+    msgctxt: string | undefined,
+    msgid: string,
+    suffix?: string,
+): string {
+    const ctx = msgctxt ?? "";
+    return suffix
+        ? `${ctx}${KEY_DELIMITER}${msgid}${KEY_DELIMITER}${suffix}`
+        : `${ctx}${KEY_DELIMITER}${msgid}`;
+}
+
+function stripPlaceholders(text: string): {
+    normalized: string;
+    map: PlaceholderMap;
+} {
+    const tokens: string[] = [];
+    let positional = false;
+    let autoIndex = 0;
+    const normalized = text.replace(PRINTF_REGEX, (match, posIdx) => {
+        if (match === "%%") return match;
+        let index: number;
+        if (posIdx) {
+            positional = true;
+            index = Number(posIdx);
+        } else {
+            autoIndex++;
+            index = autoIndex;
+        }
+
+        // Array positions are 0-based but arg indices are 1-based; keep
+        // them aligned so a re-read matches on the same index.
+        tokens[index - 1] = match;
+        return `{{arg${index}}}`;
+    });
+
+    return { map: { positional, tokens }, normalized };
+}
+
+function restorePlaceholders(text: string, map?: PlaceholderMap): string {
+    if (!map || map.tokens.length === 0) return text;
+    return text.replace(/\{\{arg(\d+)\}\}/g, (_match, idx) => {
+        const original = map.tokens[Number(idx) - 1];
+        // If the model invented an extra arg reference, leave the
+        // placeholder literal — surfacing it is better than silently
+        // deleting it. The verification step already guards this.
+        return original ?? `{{arg${idx}}}`;
+    });
+}
+
+/**
+ * Resolve the source language's plural category list from the PO
+ * header. Falls back to English-style two-form if the header is
+ * missing or unrecognized.
+ * @param headers - the parsed PO header map
+ * @returns the source language's ordered plural category list
+ */
+function inferSourceCategories(
+    headers: Record<string, string>,
+): readonly string[] {
+    const lang = headers["Language"] ?? headers["language"] ?? "";
+    const code = lang.toLowerCase().split(/[-_]/)[0];
+    if (!code) return DEFAULT_RULE.categories;
+    return getPluralRule(code).categories;
+}
+
+const POAdapter: FormatAdapter<POSidecar> = {
+    extensions: [".po"] as const,
+    name: "po",
+
+    read(raw: string): { flat: Record<string, string>; sidecar: POSidecar } {
+        const parsed = po.parse(raw);
+        const sourceCategories = inferSourceCategories(parsed.headers);
+
+        const flat: Record<string, string> = {};
+        const metaByKey: Record<string, POEntryMeta> = {};
+
+        for (const ctx of Object.keys(parsed.translations)) {
+            const bucket = parsed.translations[ctx];
+            for (const msgid of Object.keys(bucket)) {
+                const entry = bucket[msgid];
+                // The PO header is stored as the empty-msgid entry in
+                // the empty-context bucket; skip it from the flat map.
+                if (ctx === "" && msgid === "") continue;
+
+                if (entry.msgid_plural) {
+                    const msgids = [entry.msgid, entry.msgid_plural];
+                    for (let i = 0; i < msgids.length; i++) {
+                        // Source-language PO files typically only have
+                        // msgstr[0] / msgstr[1] populated when acting
+                        // as the *source*; we actually want to expose
+                        // the English msgid / msgid_plural for the
+                        // pipeline to translate, since msgstr is the
+                        // target-language slot. For a pristine source
+                        // PO (msgstr empty) this is the only sensible
+                        // shape anyway.
+                        const text = msgids[i];
+                        const suffix = i === 0 ? "_one" : "_other";
+                        const { normalized, map } = stripPlaceholders(text);
+                        const key = makeKey(entry.msgctxt, entry.msgid, suffix);
+                        flat[key] = normalized;
+                        metaByKey[key] = {
+                            comments: entry.comments,
+                            isPlural: true,
+                            msgctxt: entry.msgctxt,
+                            msgid: entry.msgid,
+                            placeholders: map,
+                        };
+                    }
+                } else {
+                    const { normalized, map } = stripPlaceholders(entry.msgid);
+                    const key = makeKey(entry.msgctxt, entry.msgid);
+                    flat[key] = normalized;
+                    metaByKey[key] = {
+                        comments: entry.comments,
+                        isPlural: false,
+                        msgctxt: entry.msgctxt,
+                        msgid: entry.msgid,
+                        placeholders: map,
+                    };
+                }
+            }
+        }
+
+        return {
+            flat,
+            sidecar: {
+                kind: "po",
+                metaByKey,
+                parsed,
+                sourceCategories,
+            },
+        };
+    },
+
+    write(
+        translated: Record<string, string>,
+        sidecar: POSidecar,
+        _inputLanguageCode: string,
+        outputLanguageCode: string,
+    ): string {
+        const targetRule = getPluralRule(outputLanguageCode);
+
+        // Deep-clone the parsed table so we don't mutate the sidecar
+        // held by the caller (translateDiff may reuse it).
+        const out: GetTextTranslations = {
+            charset: sidecar.parsed.charset,
+            headers: { ...sidecar.parsed.headers },
+            obsolete: sidecar.parsed.obsolete,
+            translations: {},
+        };
+
+        // Update the header to reflect the target language's plurals.
+        out.headers["Plural-Forms"] = targetRule.forms;
+        out.headers["Language"] = outputLanguageCode;
+
+        for (const ctx of Object.keys(sidecar.parsed.translations)) {
+            out.translations[ctx] = {};
+            const bucket = sidecar.parsed.translations[ctx];
+            for (const msgid of Object.keys(bucket)) {
+                const original = bucket[msgid];
+                if (ctx === "" && msgid === "") {
+                    // Preserve the PO header entry verbatim.
+                    out.translations[ctx][msgid] = {
+                        ...original,
+                        // gettext-parser expects msgstr to be an array.
+                        msgstr: original.msgstr,
+                    };
+                    continue;
+                }
+
+                if (original.msgid_plural) {
+                    const oneKey = makeKey(
+                        original.msgctxt,
+                        original.msgid,
+                        "_one",
+                    );
+
+                    const otherKey = makeKey(
+                        original.msgctxt,
+                        original.msgid,
+                        "_other",
+                    );
+
+                    const oneMeta = sidecar.metaByKey[oneKey];
+                    const otherMeta = sidecar.metaByKey[otherKey];
+                    const translatedOne = translated[oneKey];
+                    const translatedOther = translated[otherKey];
+
+                    // Fan-in: re-expand the two i18next plural slots
+                    // (`_one` / `_other`) into the target language's
+                    // full msgstr[] array. For a language with >2
+                    // forms we clone the `_other` slot into every
+                    // non-`one` category; it's the honest v1 behavior
+                    // given i18next's own two-form plural marking.
+                    // Each source slot carries its own placeholder map
+                    // (the singular and plural forms can differ), so
+                    // restore each pick with the matching one.
+                    const msgstr: string[] = [];
+                    for (let i = 0; i < targetRule.nplurals; i++) {
+                        const isOne = targetRule.categories[i] === "one";
+                        const pick = isOne ? translatedOne : translatedOther;
+                        const map = isOne
+                            ? oneMeta?.placeholders
+                            : otherMeta?.placeholders;
+
+                        msgstr.push(restorePlaceholders(pick ?? "", map));
+                    }
+
+                    out.translations[ctx][msgid] = {
+                        ...original,
+                        msgstr,
+                    };
+                } else {
+                    const key = makeKey(original.msgctxt, original.msgid);
+                    const meta = sidecar.metaByKey[key];
+                    const translatedText = translated[key] ?? "";
+                    out.translations[ctx][msgid] = {
+                        ...original,
+                        msgstr: [
+                            restorePlaceholders(
+                                translatedText,
+                                meta?.placeholders,
+                            ),
+                        ],
+                    };
+                }
+            }
+        }
+
+        return po.compile(out).toString("utf-8");
+    },
+};
+
+export default POAdapter;

--- a/src/formats/po_adapter.ts
+++ b/src/formats/po_adapter.ts
@@ -187,6 +187,68 @@ const POAdapter: FormatAdapter<POSidecar> = {
         };
     },
 
+    readTranslated(raw: string): {
+        flat: Record<string, string>;
+        sidecar: POSidecar;
+    } {
+        // Diff mode: read an existing *target* catalogue, exposing the
+        // translated `msgstr` values (not `msgid`) keyed exactly as
+        // `read` keys the source, so unchanged keys line up and survive.
+        // Values are kept verbatim (placeholders not normalized): on
+        // write they pass through restorePlaceholders, which is a no-op
+        // when no `{{argN}}` tokens are present.
+        const parsed = po.parse(raw);
+        const sourceCategories = inferSourceCategories(parsed.headers);
+        const oneIndex = Math.max(0, sourceCategories.indexOf("one"));
+        const otherIndex = sourceCategories.findIndex((c) => c !== "one");
+
+        const flat: Record<string, string> = {};
+        const metaByKey: Record<string, POEntryMeta> = {};
+
+        for (const ctx of Object.keys(parsed.translations)) {
+            const bucket = parsed.translations[ctx];
+            for (const msgid of Object.keys(bucket)) {
+                const entry = bucket[msgid];
+                if (ctx === "" && msgid === "") continue;
+
+                if (entry.msgid_plural) {
+                    const oneKey = makeKey(entry.msgctxt, entry.msgid, "_one");
+                    const otherKey = makeKey(
+                        entry.msgctxt,
+                        entry.msgid,
+                        "_other",
+                    );
+
+                    flat[oneKey] = entry.msgstr[oneIndex] ?? "";
+                    flat[otherKey] =
+                        entry.msgstr[otherIndex >= 0 ? otherIndex : 0] ?? "";
+
+                    metaByKey[oneKey] = {
+                        comments: entry.comments,
+                        isPlural: true,
+                        msgctxt: entry.msgctxt,
+                        msgid: entry.msgid,
+                    };
+                    metaByKey[otherKey] = metaByKey[oneKey];
+                } else {
+                    const key = makeKey(entry.msgctxt, entry.msgid);
+                    flat[key] = entry.msgstr[0] ?? "";
+                    metaByKey[key] = {
+                        comments: entry.comments,
+                        isPlural: false,
+                        msgctxt: entry.msgctxt,
+                        msgid: entry.msgid,
+                    };
+                }
+            }
+        }
+
+        return {
+            flat,
+            sidecar: { kind: "po", metaByKey, parsed, sourceCategories },
+        };
+    },
+
     write(
         translated: Record<string, string>,
         sidecar: POSidecar,

--- a/src/formats/po_plural_rules.ts
+++ b/src/formats/po_plural_rules.ts
@@ -1,0 +1,111 @@
+/**
+ * Minimal table of Gettext Plural-Forms rules keyed by ISO-639-1 code.
+ * The `categories` array is the CLDR plural-category name for each
+ * index `i` in `msgstr[i]`. The `forms` string is the literal value
+ * for the `Plural-Forms:` header on write.
+ *
+ * Covers the common languages a first-pass user is likely to target.
+ * Unknown codes fall back to 2-form English-style via `DEFAULT_RULE`.
+ * Expanding coverage is additive — it doesn't require touching the
+ * adapter logic.
+ *
+ * Source: GNU gettext manual & Mozilla Localization plural rules.
+ */
+export type PluralRule = {
+    /** Number of msgstr slots for a plural entry in this language. */
+    nplurals: number;
+    /** CLDR category name at each msgstr index. */
+    categories: readonly PluralCategory[];
+    /** Value to write into the `Plural-Forms:` header. */
+    forms: string;
+};
+
+export type PluralCategory =
+    | "zero"
+    | "one"
+    | "two"
+    | "few"
+    | "many"
+    | "other";
+
+export const DEFAULT_RULE: PluralRule = {
+    categories: ["one", "other"],
+    forms: "nplurals=2; plural=(n != 1);",
+    nplurals: 2,
+};
+
+export const PLURAL_RULES: Record<string, PluralRule> = {
+    ar: {
+        categories: ["zero", "one", "two", "few", "many", "other"],
+        forms: "nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);",
+        nplurals: 6,
+    },
+    cs: {
+        categories: ["one", "few", "other"],
+        forms: "nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);",
+        nplurals: 3,
+    },
+    de: DEFAULT_RULE,
+    en: DEFAULT_RULE,
+    es: DEFAULT_RULE,
+    fr: {
+        categories: ["one", "other"],
+        forms: "nplurals=2; plural=(n > 1);",
+        nplurals: 2,
+    },
+    it: DEFAULT_RULE,
+    ja: {
+        categories: ["other"],
+        forms: "nplurals=1; plural=0;",
+        nplurals: 1,
+    },
+    ko: {
+        categories: ["other"],
+        forms: "nplurals=1; plural=0;",
+        nplurals: 1,
+    },
+    nl: DEFAULT_RULE,
+    pl: {
+        categories: ["one", "few", "many"],
+        forms: "nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);",
+        nplurals: 3,
+    },
+    pt: {
+        categories: ["one", "other"],
+        forms: "nplurals=2; plural=(n != 1);",
+        nplurals: 2,
+    },
+    ru: {
+        categories: ["one", "few", "many"],
+        forms: "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);",
+        nplurals: 3,
+    },
+    tr: {
+        categories: ["one", "other"],
+        forms: "nplurals=2; plural=(n > 1);",
+        nplurals: 2,
+    },
+    uk: {
+        categories: ["one", "few", "many"],
+        forms: "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);",
+        nplurals: 3,
+    },
+    vi: {
+        categories: ["other"],
+        forms: "nplurals=1; plural=0;",
+        nplurals: 1,
+    },
+    zh: {
+        categories: ["other"],
+        forms: "nplurals=1; plural=0;",
+        nplurals: 1,
+    },
+};
+
+/**
+ * @param languageCode - ISO-639-1 code (case-insensitive)
+ * @returns the plural rule for the language, or `DEFAULT_RULE`
+ */
+export function getPluralRule(languageCode: string): PluralRule {
+    return PLURAL_RULES[languageCode.toLowerCase()] ?? DEFAULT_RULE;
+}

--- a/src/formats/registry.ts
+++ b/src/formats/registry.ts
@@ -1,0 +1,54 @@
+import JSONAdapter from "./json_adapter";
+import POAdapter from "./po_adapter";
+import path from "path";
+import type FormatAdapter from "./format_adapter";
+
+// Sidecar types are adapter-private; the registry holds adapters with
+// the sidecar type erased so we can dispatch on extension or name
+// without leaking each format's internal shape.
+const ADAPTERS: readonly FormatAdapter<unknown>[] = [JSONAdapter, POAdapter];
+
+/**
+ * Look up an adapter by its `--format <name>` identifier.
+ * @param name - adapter name (e.g. `"json"`)
+ * @returns the matching adapter, or undefined
+ */
+export function getAdapterByName(
+    name: string,
+): FormatAdapter<unknown> | undefined {
+    return ADAPTERS.find((a) => a.name === name);
+}
+
+/**
+ * Look up an adapter by file extension (leading dot included or not).
+ * @param ext - the file extension, case-insensitive
+ * @returns the matching adapter, or undefined
+ */
+export function getAdapterByExtension(
+    ext: string,
+): FormatAdapter<unknown> | undefined {
+    const normalized = ext.startsWith(".")
+        ? ext.toLowerCase()
+        : `.${ext.toLowerCase()}`;
+
+    return ADAPTERS.find((a) => a.extensions.includes(normalized));
+}
+
+/**
+ * Resolve an adapter from a filename, or fall back to the default
+ * JSON adapter. Used by the file wrappers when the caller hasn't
+ * passed `--format` explicitly.
+ * @param filename - the filename to inspect
+ * @returns the matching adapter, or the JSON default
+ */
+export function getAdapterForFile(filename: string): FormatAdapter<unknown> {
+    const ext = path.extname(filename);
+    return getAdapterByExtension(ext) ?? JSONAdapter;
+}
+
+/**
+ * @returns the names of every registered adapter
+ */
+export function listFormatNames(): string[] {
+    return ADAPTERS.map((a) => a.name);
+}

--- a/src/interfaces/translate_directory_diff_options.ts
+++ b/src/interfaces/translate_directory_diff_options.ts
@@ -7,4 +7,6 @@ export default interface TranslateDirectoryDiffOptions extends Options {
     inputFolderNameBefore: string;
     inputFolderNameAfter: string;
     dryRun?: DryRun;
+    /** Format adapter name; inferred per file from extension when unset. */
+    format?: string;
 }

--- a/src/interfaces/translate_directory_options.ts
+++ b/src/interfaces/translate_directory_options.ts
@@ -7,4 +7,6 @@ export default interface TranslateDirectoryOptions extends Options {
     outputLanguageCode: string;
     dryRun?: DryRun;
     forceLanguageName?: string;
+    /** Format adapter name; inferred per file from extension when unset. */
+    format?: string;
 }

--- a/src/interfaces/translate_file_diff_options.ts
+++ b/src/interfaces/translate_file_diff_options.ts
@@ -6,4 +6,6 @@ export default interface TranslateFileDiffOptions extends Options {
     inputBeforeFileOrPath: string;
     inputAfterFileOrPath: string;
     dryRun?: DryRun;
+    /** Format adapter name; inferred from extension when unset. */
+    format?: string;
 }

--- a/src/interfaces/translate_file_options.ts
+++ b/src/interfaces/translate_file_options.ts
@@ -6,4 +6,10 @@ export default interface TranslateFileOptions extends Options {
     outputFilePath: string;
     dryRun?: DryRun;
     forceLanguageName?: string;
+    /**
+     * Format adapter name (e.g. `"json"`). When unset, the adapter is
+     * inferred from the input file's extension. Unknown extensions fall
+     * back to the JSON adapter for backwards compatibility.
+     */
+    format?: string;
 }

--- a/src/test/formats.spec.ts
+++ b/src/test/formats.spec.ts
@@ -183,4 +183,221 @@ describe("POAdapter", () => {
             "%d items",
         ]);
     });
+
+    it("leaves a %% literal untouched on read and write", () => {
+        const fixture = [
+            "msgid \"\"",
+            "msgstr \"\"",
+            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
+            "\"Language: en\\n\"",
+            "",
+            // `%%` is an escaped literal percent, not an arg slot; the
+            // adjacent `%s` is the only real placeholder (→ {{arg1}}).
+            "msgid \"100%% done with %s\"",
+            "msgstr \"\"",
+            "",
+        ].join("\n");
+
+        const { flat, sidecar } = POAdapter.read(fixture);
+        expect(flat[`${SEP}100%% done with %s`]).toBe(
+            "100%% done with {{arg1}}",
+        );
+
+        const output = POAdapter.write(flat, sidecar, "en", "en");
+        const reparsed = po.parse(output);
+        expect(
+            reparsed.translations[""]["100%% done with %s"].msgstr[0],
+        ).toBe("100%% done with %s");
+    });
+
+    it("preserves width / precision specifiers across the round-trip", () => {
+        const fixture = [
+            "msgid \"\"",
+            "msgstr \"\"",
+            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
+            "\"Language: en\\n\"",
+            "",
+            "msgid \"%.2f kg at %3d items\"",
+            "msgstr \"\"",
+            "",
+        ].join("\n");
+
+        const { flat, sidecar } = POAdapter.read(fixture);
+        expect(flat[`${SEP}%.2f kg at %3d items`]).toBe(
+            "{{arg1}} kg at {{arg2}} items",
+        );
+
+        const output = POAdapter.write(flat, sidecar, "en", "en");
+        const reparsed = po.parse(output);
+        expect(
+            reparsed.translations[""]["%.2f kg at %3d items"].msgstr[0],
+        ).toBe("%.2f kg at %3d items");
+    });
+
+    it("leaves a model-invented arg reference literal instead of dropping it", () => {
+        const fixture = [
+            "msgid \"\"",
+            "msgstr \"\"",
+            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
+            "\"Language: en\\n\"",
+            "",
+            "msgid \"Hi %s\"",
+            "msgstr \"\"",
+            "",
+        ].join("\n");
+
+        const { sidecar } = POAdapter.read(fixture);
+        const key = `${SEP}Hi %s`;
+
+        // The model hallucinated a second placeholder the source never
+        // had; arg1 restores to %s, arg2 has no token so it stays as the
+        // literal {{arg2}} rather than silently vanishing.
+        const output = POAdapter.write(
+            { [key]: "{{arg1}} plus {{arg2}}" },
+            sidecar,
+            "en",
+            "en",
+        );
+
+        const reparsed = po.parse(output);
+        expect(reparsed.translations[""]["Hi %s"].msgstr[0]).toBe(
+            "%s plus {{arg2}}",
+        );
+    });
+
+    it("writes empty msgstr slots when the translation map omits keys", () => {
+        // The model dropped every key from its response — write must
+        // degrade to empty msgstrs (both singular and plural slots)
+        // rather than throwing on the missing lookups.
+        const { sidecar } = POAdapter.read(PO_FIXTURE);
+        const reparsed = po.parse(POAdapter.write({}, sidecar, "en", "fr"));
+
+        expect(reparsed.translations[""]["Hello %s"].msgstr[0]).toBe("");
+        expect(reparsed.translations["menu"]["Save"].msgstr[0]).toBe("");
+        expect(reparsed.translations[""]["One item"].msgstr).toEqual(["", ""]);
+    });
+
+    it("preserves untouched entry metadata byte-for-byte through compile", () => {
+        const original = po.parse(PO_FIXTURE);
+        const { flat, sidecar } = POAdapter.read(PO_FIXTURE);
+
+        // Identity write — nothing material changes, so every source
+        // entry's structural metadata must survive po.compile intact.
+        const reparsed = po.parse(POAdapter.write(flat, sidecar, "en", "en"));
+
+        for (const ctx of Object.keys(original.translations)) {
+            for (const msgid of Object.keys(original.translations[ctx])) {
+                if (ctx === "" && msgid === "") continue;
+                const before = original.translations[ctx][msgid];
+                const after = reparsed.translations[ctx][msgid];
+                expect(after.msgid).toBe(before.msgid);
+                expect(after.msgctxt).toBe(before.msgctxt);
+                expect(after.msgid_plural).toBe(before.msgid_plural);
+                expect(after.comments).toEqual(before.comments);
+            }
+        }
+    });
+});
+
+describe("POAdapter.readTranslated", () => {
+    it("exposes singular msgstr values keyed exactly as read()", () => {
+        const target = [
+            "msgid \"\"",
+            "msgstr \"\"",
+            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
+            "\"Language: fr\\n\"",
+            "",
+            "msgctxt \"menu\"",
+            "msgid \"Save\"",
+            "msgstr \"Enregistrer\"",
+            "",
+        ].join("\n");
+
+        const { flat } = POAdapter.readTranslated!(target);
+        // Same key shape as read(): msgctxt folds into the first segment.
+        expect(flat[`menu${SEP}Save`]).toBe("Enregistrer");
+    });
+
+    it("maps a 2-form target's msgstr[] back onto _one / _other", () => {
+        const target = [
+            "msgid \"\"",
+            "msgstr \"\"",
+            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
+            "\"Plural-Forms: nplurals=2; plural=(n > 1);\\n\"",
+            "\"Language: fr\\n\"",
+            "",
+            "msgid \"One item\"",
+            "msgid_plural \"%d items\"",
+            "msgstr[0] \"Un élément\"",
+            "msgstr[1] \"%d éléments\"",
+            "",
+        ].join("\n");
+
+        const { flat } = POAdapter.readTranslated!(target);
+        // Values are kept verbatim — placeholders are NOT normalized on
+        // the translated-read path (write's restore is then a no-op).
+        expect(flat[`${SEP}One item${SEP}_one`]).toBe("Un élément");
+        expect(flat[`${SEP}One item${SEP}_other`]).toBe("%d éléments");
+    });
+
+    it("collapses a 3-form target onto _one / _other via the source header", () => {
+        const target = [
+            "msgid \"\"",
+            "msgstr \"\"",
+            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
+            "\"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\\n\"",
+            "\"Language: pl\\n\"",
+            "",
+            "msgid \"One item\"",
+            "msgid_plural \"%d items\"",
+            "msgstr[0] \"jeden element\"",
+            "msgstr[1] \"%d elementy\"",
+            "msgstr[2] \"%d elementów\"",
+            "",
+        ].join("\n");
+
+        const { flat } = POAdapter.readTranslated!(target);
+        // pl categories are [one, few, many]: index 0 → _one, and the
+        // first non-"one" slot (few, index 1) → _other.
+        expect(flat[`${SEP}One item${SEP}_one`]).toBe("jeden element");
+        expect(flat[`${SEP}One item${SEP}_other`]).toBe("%d elementy");
+    });
+
+    it("yields empty strings for a target plural with missing msgstr slots", () => {
+        const target = [
+            "msgid \"\"",
+            "msgstr \"\"",
+            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
+            "\"Language: fr\\n\"",
+            "",
+            // A half-finished target: msgstr[1] was never filled in.
+            "msgid \"One item\"",
+            "msgid_plural \"%d items\"",
+            "msgstr[0] \"Un élément\"",
+            "msgstr[1] \"\"",
+            "",
+        ].join("\n");
+
+        const { flat } = POAdapter.readTranslated!(target);
+        expect(flat[`${SEP}One item${SEP}_one`]).toBe("Un élément");
+        expect(flat[`${SEP}One item${SEP}_other`]).toBe("");
+    });
+
+    it("falls back to 2-form indices when the Language header is missing", () => {
+        const target = [
+            "msgid \"\"",
+            "msgstr \"\"",
+            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
+            "",
+            "msgid \"One item\"",
+            "msgid_plural \"%d items\"",
+            "msgstr[0] \"first\"",
+            "msgstr[1] \"second\"",
+            "",
+        ].join("\n");
+
+        const { flat } = POAdapter.readTranslated!(target);
+        expect(flat[`${SEP}One item${SEP}_one`]).toBe("first");
+        expect(flat[`${SEP}One item${SEP}_other`]).toBe("second");
+    });
 });

--- a/src/test/formats.spec.ts
+++ b/src/test/formats.spec.ts
@@ -1,0 +1,186 @@
+import {
+    getAdapterByExtension,
+    getAdapterByName,
+    getAdapterForFile,
+    listFormatNames,
+} from "../formats/registry";
+import { po } from "gettext-parser";
+import JSONAdapter from "../formats/json_adapter";
+import POAdapter from "../formats/po_adapter";
+
+// ASCII Record Separator — must match KEY_DELIMITER in po_adapter.ts.
+const SEP = "\x1e";
+
+const PO_FIXTURE = [
+    "msgid \"\"",
+    "msgstr \"\"",
+    "\"Content-Type: text/plain; charset=UTF-8\\n\"",
+    "\"Plural-Forms: nplurals=2; plural=(n != 1);\\n\"",
+    "\"Language: en\\n\"",
+    "",
+    "# translator comment",
+    "#. extracted comment",
+    "#: src/app.js:42",
+    "#, javascript-format",
+    "msgid \"Hello %s\"",
+    "msgstr \"\"",
+    "",
+    "msgctxt \"menu\"",
+    "msgid \"Save\"",
+    "msgstr \"\"",
+    "",
+    "msgid \"One item\"",
+    "msgid_plural \"%d items\"",
+    "msgstr[0] \"\"",
+    "msgstr[1] \"\"",
+    "",
+].join("\n");
+
+describe("format registry", () => {
+    it("resolves the JSON adapter by name", () => {
+        expect(getAdapterByName("json")).toBe(JSONAdapter);
+    });
+
+    it("resolves the JSON adapter by extension (dot or bare)", () => {
+        expect(getAdapterByExtension(".json")).toBe(JSONAdapter);
+        expect(getAdapterByExtension("JSON")).toBe(JSONAdapter);
+    });
+
+    it("resolves the PO adapter by name and extension", () => {
+        expect(getAdapterByName("po")).toBe(POAdapter);
+        expect(getAdapterByExtension(".po")).toBe(POAdapter);
+        expect(getAdapterForFile("en.po")).toBe(POAdapter);
+    });
+
+    it("falls back to JSONAdapter for unknown extensions", () => {
+        expect(getAdapterForFile("en.xyz")).toBe(JSONAdapter);
+    });
+
+    it("returns undefined for an unknown name", () => {
+        expect(getAdapterByName("nope")).toBeUndefined();
+    });
+
+    it("lists registered format names", () => {
+        expect(listFormatNames()).toEqual(["json", "po"]);
+    });
+});
+
+describe("JSONAdapter", () => {
+    it("round-trips an i18next nested object byte-for-byte", () => {
+        const input = `${JSON.stringify(
+            { a: { b: "hi" }, c: "there" },
+            null,
+            4,
+        )}\n`;
+
+        const { flat, sidecar } = JSONAdapter.read(input);
+        expect(flat).toEqual({ "a*b": "hi", c: "there" });
+
+        const output = JSONAdapter.write(flat, sidecar, "en", "en");
+        expect(output).toBe(input);
+    });
+
+    it("preserves keys containing dots via the custom delimiter", () => {
+        const input = `${JSON.stringify({ "foo.bar": "x" }, null, 4)}\n`;
+
+        const { flat, sidecar } = JSONAdapter.read(input);
+        expect(flat).toEqual({ "foo.bar": "x" });
+
+        const output = JSONAdapter.write(flat, sidecar, "en", "en");
+        expect(output).toBe(input);
+    });
+});
+
+describe("POAdapter", () => {
+    it("reads singular, context, and plural entries into flat keys", () => {
+        const { flat } = POAdapter.read(PO_FIXTURE);
+
+        // Singular entry keyed by (empty ctx, msgid); placeholder stripped.
+        expect(flat[`${SEP}Hello %s`]).toBe("Hello {{arg1}}");
+
+        // msgctxt becomes the first key segment.
+        expect(flat[`menu${SEP}Save`]).toBe("Save");
+
+        // Plural fans out into _one / _other suffixed keys, which the
+        // pipeline already recognizes as plural slots.
+        expect(flat[`${SEP}One item${SEP}_one`]).toBe("One item");
+        expect(flat[`${SEP}One item${SEP}_other`]).toBe("{{arg1}} items");
+    });
+
+    it("normalizes positional placeholders and restores them on write", () => {
+        const fixture = [
+            "msgid \"\"",
+            "msgstr \"\"",
+            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
+            "\"Language: en\\n\"",
+            "",
+            "msgid \"%1$s sent %2$s\"",
+            "msgstr \"\"",
+            "",
+        ].join("\n");
+
+        const { flat, sidecar } = POAdapter.read(fixture);
+        expect(flat[`${SEP}%1$s sent %2$s`]).toBe("{{arg1}} sent {{arg2}}");
+
+        const output = POAdapter.write(flat, sidecar, "en", "en");
+        const reparsed = po.parse(output);
+        expect(
+            reparsed.translations[""]["%1$s sent %2$s"].msgstr[0],
+        ).toBe("%1$s sent %2$s");
+    });
+
+    it("round-trips through write: fills msgstr, restores placeholders, preserves comments", () => {
+        const { flat, sidecar } = POAdapter.read(PO_FIXTURE);
+
+        // Identity "translation" — exercises the restore + fan-in paths
+        // without a live model.
+        const output = POAdapter.write(flat, sidecar, "en", "fr");
+        const reparsed = po.parse(output);
+
+        // Header retargeted to the output language.
+        expect(reparsed.headers["Language"]).toBe("fr");
+        expect(reparsed.headers["Plural-Forms"]).toBe(
+            "nplurals=2; plural=(n > 1);",
+        );
+
+        // Placeholders restored to their native printf tokens.
+        expect(reparsed.translations[""]["Hello %s"].msgstr[0]).toBe(
+            "Hello %s",
+        );
+
+        expect(reparsed.translations["menu"]["Save"].msgstr[0]).toBe("Save");
+
+        // fr has two plural forms (one / other).
+        expect(reparsed.translations[""]["One item"].msgstr).toEqual([
+            "One item",
+            "%d items",
+        ]);
+
+        // Non-translatable metadata survives the round-trip.
+        const comments = reparsed.translations[""]["Hello %s"].comments;
+        expect(comments?.translator).toBe("translator comment");
+        expect(comments?.extracted).toBe("extracted comment");
+        expect(comments?.reference).toBe("src/app.js:42");
+        expect(comments?.flag).toBe("javascript-format");
+    });
+
+    it("fans plural slots into a 3-form target language", () => {
+        const { flat, sidecar } = POAdapter.read(PO_FIXTURE);
+
+        const output = POAdapter.write(flat, sidecar, "en", "pl");
+        const reparsed = po.parse(output);
+
+        expect(reparsed.headers["Plural-Forms"]).toBe(
+            "nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);",
+        );
+
+        // _one fills the "one" slot; _other is cloned into the two
+        // remaining (few / many) slots — the honest v1 behavior given
+        // i18next only marks two plural forms.
+        expect(reparsed.translations[""]["One item"].msgstr).toEqual([
+            "One item",
+            "%d items",
+            "%d items",
+        ]);
+    });
+});

--- a/src/test/translate.spec.ts
+++ b/src/test/translate.spec.ts
@@ -56,9 +56,27 @@ import Engine from "../enums/engine";
 import PromptMode from "../enums/prompt_mode";
 // eslint-disable-next-line import/first
 import RateLimiter from "../rate_limiter";
+// eslint-disable-next-line import/first
+import { po } from "gettext-parser";
 
 const mkCaseDir = (): string =>
     fs.mkdtempSync(path.join(os.tmpdir(), "i18n-case-"));
+
+// Minimal PO file: a header plus one msgid/msgstr per pair. Source
+// files pass "" for the msgstr; target files carry existing values.
+const poFile = (lang: string, pairs: Array<[string, string]>): string =>
+    [
+        "msgid \"\"",
+        "msgstr \"\"",
+        "\"Content-Type: text/plain; charset=UTF-8\\n\"",
+        `"Language: ${lang}\\n"`,
+        "",
+        ...pairs.flatMap(([id, str]) => [
+            `msgid "${id}"`,
+            `msgstr "${str}"`,
+            "",
+        ]),
+    ].join("\n");
 
 describe.each(Object.values(PromptMode))(
     "translate (promptMode=%s)",
@@ -531,10 +549,12 @@ describe.each(Object.values(PromptMode))(
                 path.join(enBefore, "app.json"),
                 JSON.stringify({ keepA: "A", keepB: "B" }),
             );
+
             fs.writeFileSync(
                 path.join(enAfter, "app.json"),
                 JSON.stringify({ added: "New", keepA: "A", keepB: "B" }),
             );
+
             fs.writeFileSync(
                 path.join(frDir, "app.json"),
                 JSON.stringify({
@@ -721,6 +741,144 @@ describe.each(Object.values(PromptMode))(
         });
     },
 );
+
+describe("PO format end-to-end (mocked pipeline)", () => {
+    it("translateFile writes a translated .po sibling", async () => {
+        const dir = mkCaseDir();
+        const inputPath = path.join(dir, "en.po");
+        const outputPath = path.join(dir, "fr.po");
+
+        fs.writeFileSync(
+            inputPath,
+            poFile("en", [
+                ["Cat", ""],
+                ["Dog", ""],
+            ]),
+        );
+
+        await translateFile({
+            engine: Engine.ChatGPT,
+            forceLanguageName: "fr",
+            inputFilePath: inputPath,
+            inputLanguageCode: "en",
+            model: "gpt-4o",
+            outputFilePath: outputPath,
+            promptMode: PromptMode.JSON,
+            rateLimitMs: 0,
+        } as any);
+
+        const parsed = po.parse(fs.readFileSync(outputPath, "utf-8"));
+        expect(parsed.translations[""].Cat.msgstr[0]).toBe(fr("Cat"));
+        expect(parsed.translations[""].Dog.msgstr[0]).toBe(fr("Dog"));
+    });
+
+    it("translateFileDiff updates changed keys and preserves existing msgstr", async () => {
+        const dir = mkCaseDir();
+        const beforePath = path.join(dir, "before_en.po");
+        const afterPath = path.join(dir, "after_en.po");
+        const frPath = path.join(dir, "fr.po");
+
+        fs.writeFileSync(beforePath, poFile("en", [["Cat", ""]]));
+        fs.writeFileSync(
+            afterPath,
+            poFile("en", [
+                ["Cat", ""],
+                ["Dog", ""],
+            ]),
+        );
+        fs.writeFileSync(frPath, poFile("fr", [["Cat", "Chat"]]));
+
+        await translateFileDiff({
+            engine: Engine.ChatGPT,
+            inputAfterFileOrPath: afterPath,
+            inputBeforeFileOrPath: beforePath,
+            inputLanguageCode: "en",
+            model: "gpt-4o",
+            promptMode: PromptMode.JSON,
+            rateLimitMs: 0,
+        } as any);
+
+        const parsed = po.parse(fs.readFileSync(frPath, "utf-8"));
+        // 'Cat' was unchanged in the source, so its existing translation
+        // survives; 'Dog' is new and gets translated.
+        expect(parsed.translations[""].Cat.msgstr[0]).toBe("Chat");
+        expect(parsed.translations[""].Dog.msgstr[0]).toBe(fr("Dog"));
+    });
+
+    it("translateDirectory replicates a .po file for the target language", async () => {
+        const dir = mkCaseDir();
+        const enDir = path.join(dir, "en");
+        fs.mkdirSync(enDir, { recursive: true });
+
+        fs.writeFileSync(
+            path.join(enDir, "app.po"),
+            poFile("en", [["Cat", ""]]),
+        );
+
+        await translateDirectory({
+            baseDirectory: dir,
+            engine: Engine.ChatGPT,
+            inputLanguageCode: "en",
+            model: "gpt-4o",
+            outputLanguageCode: "fr",
+            promptMode: PromptMode.JSON,
+            rateLimitMs: 0,
+        } as any);
+
+        const parsed = po.parse(
+            fs.readFileSync(path.join(dir, "fr", "app.po"), "utf-8"),
+        );
+
+        expect(parsed.translations[""].Cat.msgstr[0]).toBe(fr("Cat"));
+    });
+
+    it("translateDirectoryDiff preserves existing .po msgstr and adds new keys", async () => {
+        const dir = mkCaseDir();
+        const enBefore = path.join(dir, "en_before");
+        const enAfter = path.join(dir, "en_after");
+        const frDir = path.join(dir, "fr");
+
+        fs.mkdirSync(enBefore, { recursive: true });
+        fs.mkdirSync(enAfter, { recursive: true });
+        fs.mkdirSync(frDir, { recursive: true });
+
+        fs.writeFileSync(
+            path.join(enBefore, "app.po"),
+            poFile("en", [["Cat", ""]]),
+        );
+
+        fs.writeFileSync(
+            path.join(enAfter, "app.po"),
+            poFile("en", [
+                ["Cat", ""],
+                ["Dog", ""],
+            ]),
+        );
+
+        fs.writeFileSync(
+            path.join(frDir, "app.po"),
+            poFile("fr", [["Cat", "Chat"]]),
+        );
+
+        await translateDirectoryDiff({
+            baseDirectory: dir,
+            engine: Engine.ChatGPT,
+            inputFolderNameAfter: "en_after",
+            inputFolderNameBefore: "en_before",
+            inputLanguageCode: "en",
+            model: "gpt-4o",
+            promptMode: PromptMode.JSON,
+            rateLimitMs: 0,
+        } as any);
+
+        const parsed = po.parse(
+            fs.readFileSync(path.join(frDir, "app.po"), "utf-8"),
+        );
+
+        expect(parsed.translations[""].Cat.msgstr[0]).toBe("Chat");
+        expect(parsed.translations[""].Dog.msgstr[0]).toBe(fr("Dog"));
+    });
+});
 
 describe("RateLimiter", () => {
     const mockedDelay = utils.delay as jest.MockedFunction<typeof utils.delay>;

--- a/src/translate_directory.ts
+++ b/src/translate_directory.ts
@@ -1,18 +1,21 @@
-import { FLATTEN_DELIMITER } from "./constants";
-import { createPatch, diffJson } from "diff";
-import { flatten, unflatten } from "flat";
 import {
     DIRECTORY_KEY_DELIMITER,
     getAllFilesInPath,
     getTranslationDirectoryKey,
+    getTranslationDirectoryPath,
     printError,
     printInfo,
     resolveInputPath,
 } from "./utils";
+import { FLATTEN_DELIMITER } from "./constants";
+import { createPatch, diffJson } from "diff";
+import { flatten } from "flat";
+import { getAdapterByName, getAdapterForFile } from "./formats/registry";
 import { translate, translateDiff } from "./translate";
 import colors from "colors/safe";
 import fs from "fs";
 import path, { dirname } from "path";
+import type FormatAdapter from "./formats/format_adapter";
 import type TranslateDirectoryDiffOptions from "./interfaces/translate_directory_diff_options";
 import type TranslateDirectoryOptions from "./interfaces/translate_directory_options";
 
@@ -39,17 +42,41 @@ export async function translateDirectory(
 
     const sourceFilePaths = getAllFilesInPath(sourceLanguagePath);
     const inputJSON: { [key: string]: string } = {};
-    for (const sourceFilePath of sourceFilePaths) {
-        const fileContents = fs.readFileSync(sourceFilePath, "utf-8");
-        const fileJSON = JSON.parse(fileContents);
-        const flatJSON = flatten(fileJSON, {
-            delimiter: FLATTEN_DELIMITER,
-        }) as {
-            [key: string]: string;
+    // Per source file, remember the adapter that handled it and the
+    // sidecar from its read, keyed by the *output* path that
+    // getTranslationDirectoryKey embeds. The write loop recovers the
+    // same path by splitting the compound key, then uses these to
+    // reconstruct each file in its own format.
+    const fileAdapters: {
+        [outputPath: string]: {
+            adapter: FormatAdapter<unknown>;
+            sidecar: unknown;
         };
+    } = {};
 
-        for (const key in flatJSON) {
-            if (Object.prototype.hasOwnProperty.call(flatJSON, key)) {
+    for (const sourceFilePath of sourceFilePaths) {
+        const adapter = options.format
+            ? getAdapterByName(options.format)
+            : getAdapterForFile(sourceFilePath);
+
+        if (!adapter) {
+            throw new Error(`Unknown format: ${options.format}`);
+        }
+
+        const { flat, sidecar } = adapter.read(
+            fs.readFileSync(sourceFilePath, "utf-8"),
+        );
+
+        fileAdapters[
+            getTranslationDirectoryPath(
+                sourceFilePath,
+                options.inputLanguageCode,
+                options.outputLanguageCode,
+            )
+        ] = { adapter, sidecar };
+
+        for (const key in flat) {
+            if (Object.prototype.hasOwnProperty.call(flat, key)) {
                 inputJSON[
                     getTranslationDirectoryKey(
                         sourceFilePath,
@@ -57,7 +84,7 @@ export async function translateDirectory(
                         options.inputLanguageCode,
                         options.outputLanguageCode,
                     )
-                ] = flatJSON[key];
+                ] = flat[key];
             }
         }
     }
@@ -77,9 +104,14 @@ export async function translateDirectory(
             inputJSON,
             inputLanguageCode: inputLanguage,
             outputLanguageCode: outputLanguage,
-        })) as { [filePathKey: string]: string };
+        })) as { [filePathKey: string]: unknown };
 
-        const filesToJSON: { [filePath: string]: { [key: string]: string } } =
+        // Regroup the flat compound-keyed output back into per-file
+        // objects. A value may be a nested object (JSON, which translate
+        // re-nests on the FLATTEN_DELIMITER) or a string (formats whose
+        // keys carry no delimiter); re-flattening below normalises both
+        // back to each adapter's flat-map contract.
+        const filesToObj: { [filePath: string]: { [key: string]: unknown } } =
             {};
 
         for (const pathWithKey in outputJSON) {
@@ -88,100 +120,111 @@ export async function translateDirectory(
                     .split(DIRECTORY_KEY_DELIMITER)
                     .slice(0, -1)
                     .join(DIRECTORY_KEY_DELIMITER);
-                if (!filesToJSON[filePath]) {
-                    filesToJSON[filePath] = {};
+
+                if (!filesToObj[filePath]) {
+                    filesToObj[filePath] = {};
                 }
 
                 const key = pathWithKey.split(DIRECTORY_KEY_DELIMITER).pop()!;
-                filesToJSON[filePath][key] = outputJSON[pathWithKey];
+                filesToObj[filePath][key] = outputJSON[pathWithKey];
             }
         }
 
-        for (const perFileJSON in filesToJSON) {
+        for (const perFilePath in filesToObj) {
             if (
-                Object.prototype.hasOwnProperty.call(filesToJSON, perFileJSON)
+                !Object.prototype.hasOwnProperty.call(filesToObj, perFilePath)
             ) {
-                const unflattenedOutput = unflatten(filesToJSON[perFileJSON], {
-                    delimiter: FLATTEN_DELIMITER,
-                });
+                continue;
+            }
 
-                const outputText = JSON.stringify(unflattenedOutput, null, 4);
-                if (!options.dryRun) {
-                    fs.mkdirSync(dirname(perFileJSON), { recursive: true });
-                    fs.writeFileSync(perFileJSON, `${outputText}\n`);
-                } else {
-                    // TODO: find a cleaner way to get the input file from here
-                    // Might lead to a bug if the path has the language code multiple times
-                    const relativeOutputPath = path.relative(
-                        options.baseDirectory,
-                        perFileJSON,
-                    );
+            const { adapter, sidecar } = fileAdapters[perFilePath];
+            const perFileFlat = flatten(filesToObj[perFilePath], {
+                delimiter: FLATTEN_DELIMITER,
+            }) as { [key: string]: string };
 
-                    const input = fs.readFileSync(
-                        perFileJSON.replace(
-                            `/${outputLanguage}/`,
-                            `/${inputLanguage}/`,
-                        ),
-                        "utf-8",
-                    );
+            const outputText = adapter.write(
+                perFileFlat,
+                sidecar,
+                inputLanguage,
+                outputLanguage,
+            );
 
-                    const translationDiff = diffJson(input, outputText);
-                    fs.mkdirSync(
-                        dirname(
-                            `${options.dryRun.basePath}/${relativeOutputPath}`,
-                        ),
-                        { recursive: true },
-                    );
+            if (!options.dryRun) {
+                fs.mkdirSync(dirname(perFilePath), { recursive: true });
+                fs.writeFileSync(perFilePath, outputText);
+            } else {
+                // TODO: find a cleaner way to get the input file from here
+                // Might lead to a bug if the path has the language code multiple times
+                const relativeOutputPath = path.relative(
+                    options.baseDirectory,
+                    perFilePath,
+                );
 
-                    fs.writeFileSync(
-                        `${options.dryRun.basePath}/${relativeOutputPath}`,
-                        outputText,
-                    );
+                const inputRaw = fs.readFileSync(
+                    perFilePath.replace(
+                        `/${outputLanguage}/`,
+                        `/${inputLanguage}/`,
+                    ),
+                    "utf-8",
+                );
 
-                    const patch = createPatch(
-                        perFileJSON, // Use the absolute path for the patch header
-                        input,
-                        outputText,
-                    );
+                fs.mkdirSync(
+                    dirname(`${options.dryRun.basePath}/${relativeOutputPath}`),
+                    { recursive: true },
+                );
 
-                    fs.writeFileSync(
-                        `${options.dryRun.basePath}/${relativeOutputPath}.patch`,
-                        patch,
-                    );
+                fs.writeFileSync(
+                    `${options.dryRun.basePath}/${relativeOutputPath}`,
+                    outputText,
+                );
 
-                    printInfo(
-                        `Wrote new JSON to ${options.dryRun.basePath}/${relativeOutputPath}`,
-                    );
+                const patch = createPatch(
+                    perFilePath, // Use the absolute path for the patch header
+                    inputRaw,
+                    outputText,
+                );
 
-                    printInfo(
-                        `Wrote patch to ${options.dryRun.basePath}/${relativeOutputPath}.patch`,
-                    );
-                    if (options.verbose) {
-                        for (const part of translationDiff) {
-                            const colorFns = {
-                                green: colors.green,
-                                grey: colors.grey,
-                                red: colors.red,
-                            } as const;
+                fs.writeFileSync(
+                    `${options.dryRun.basePath}/${relativeOutputPath}.patch`,
+                    patch,
+                );
 
-                            type ColorKey = keyof typeof colorFns;
+                printInfo(
+                    `Wrote new ${adapter.name} to ${options.dryRun.basePath}/${relativeOutputPath}`,
+                );
 
-                            let color: ColorKey;
+                printInfo(
+                    `Wrote patch to ${options.dryRun.basePath}/${relativeOutputPath}.patch`,
+                );
 
-                            if (part.added) {
-                                color = "green";
-                            } else if (part.removed) {
-                                color = "red";
-                            } else {
-                                color = "grey";
-                            }
+                // The colored inline diff is JSON-aware; other adapters
+                // still emit the patch file but skip the terminal diff.
+                if (options.verbose && adapter.name === "json") {
+                    const translationDiff = diffJson(inputRaw, outputText);
+                    for (const part of translationDiff) {
+                        const colorFns = {
+                            green: colors.green,
+                            grey: colors.grey,
+                            red: colors.red,
+                        } as const;
 
-                            process.stderr.write(colorFns[color](part.value));
+                        type ColorKey = keyof typeof colorFns;
+
+                        let color: ColorKey;
+
+                        if (part.added) {
+                            color = "green";
+                        } else if (part.removed) {
+                            color = "red";
+                        } else {
+                            color = "grey";
                         }
-                    }
 
-                    console.log();
+                        process.stderr.write(colorFns[color](part.value));
+                    }
                 }
+
+                console.log();
             }
         }
     } catch (err) {
@@ -224,54 +267,79 @@ export async function translateDirectoryDiff(
         );
     }
 
+    const resolveAdapter = (file: string): FormatAdapter<unknown> => {
+        const adapter = options.format
+            ? getAdapterByName(options.format)
+            : getAdapterForFile(file);
+
+        if (!adapter) {
+            throw new Error(`Unknown format: ${options.format}`);
+        }
+
+        return adapter;
+    };
+
     // TODO: abstract to fn
     const sourceFilePathsBefore = getAllFilesInPath(sourceLanguagePathBefore);
     const inputJSONBefore: { [key: string]: string } = {};
     for (const sourceFilePath of sourceFilePathsBefore) {
-        const fileContents = fs.readFileSync(sourceFilePath, "utf-8");
-        const fileJSON = JSON.parse(fileContents);
-        const flatJSON = flatten(fileJSON, {
-            delimiter: FLATTEN_DELIMITER,
-        }) as {
-            [key: string]: string;
-        };
+        const { flat } = resolveAdapter(sourceFilePath).read(
+            fs.readFileSync(sourceFilePath, "utf-8"),
+        );
 
-        for (const key in flatJSON) {
-            if (Object.prototype.hasOwnProperty.call(flatJSON, key)) {
+        for (const key in flat) {
+            if (Object.prototype.hasOwnProperty.call(flat, key)) {
                 inputJSONBefore[
                     getTranslationDirectoryKey(
                         sourceFilePath,
                         key,
                         options.inputLanguageCode,
                     )
-                ] = flatJSON[key];
+                ] = flat[key];
             }
         }
     }
 
+    // The *after* catalogue is what every target file is rebuilt from,
+    // so keep each file's adapter + sidecar keyed by the before-folder
+    // path that the compound keys carry (writeLanguageOutput recovers
+    // the same path by splitting the key).
+    const fileAdapters: {
+        [beforePath: string]: {
+            adapter: FormatAdapter<unknown>;
+            sidecar: unknown;
+        };
+    } = {};
+
     const sourceFilePathsAfter = getAllFilesInPath(sourceLanguagePathAfter);
     const inputJSONAfter: { [key: string]: string } = {};
     for (const sourceFilePath of sourceFilePathsAfter) {
-        const fileContents = fs.readFileSync(sourceFilePath, "utf-8");
-        const fileJSON = JSON.parse(fileContents);
-        const flatJSON = flatten(fileJSON, {
-            delimiter: FLATTEN_DELIMITER,
-        }) as {
-            [key: string]: string;
-        };
+        const adapter = resolveAdapter(sourceFilePath);
+        const { flat, sidecar } = adapter.read(
+            fs.readFileSync(sourceFilePath, "utf-8"),
+        );
 
-        for (const key in flatJSON) {
-            if (Object.prototype.hasOwnProperty.call(flatJSON, key)) {
+        const beforeEquivalentPath = sourceFilePath.replace(
+            options.inputFolderNameAfter,
+            options.inputFolderNameBefore,
+        );
+
+        fileAdapters[
+            getTranslationDirectoryPath(
+                beforeEquivalentPath,
+                options.inputLanguageCode,
+            )
+        ] = { adapter, sidecar };
+
+        for (const key in flat) {
+            if (Object.prototype.hasOwnProperty.call(flat, key)) {
                 inputJSONAfter[
                     getTranslationDirectoryKey(
-                        sourceFilePath.replace(
-                            options.inputFolderNameAfter,
-                            options.inputFolderNameBefore,
-                        ),
+                        beforeEquivalentPath,
                         key,
                         options.inputLanguageCode,
                     )
-                ] = flatJSON[key];
+                ] = flat[key];
             }
         }
     }
@@ -293,13 +361,13 @@ export async function translateDirectoryDiff(
     for (const outputLanguagePath of outputLanguagePaths) {
         const files = getAllFilesInPath(outputLanguagePath);
         for (const file of files) {
-            const fileContents = fs.readFileSync(file, "utf-8");
-            const fileJSON = JSON.parse(fileContents);
-            const flatJSON = flatten(fileJSON, {
-                delimiter: FLATTEN_DELIMITER,
-            }) as {
-                [key: string]: string;
-            };
+            const adapter = resolveAdapter(file);
+            const raw = fs.readFileSync(file, "utf-8");
+            // Existing target translations: read msgstr-style slots when
+            // the format separates source from target, else fall back.
+            const flat = adapter.readTranslated
+                ? adapter.readTranslated(raw).flat
+                : adapter.read(raw).flat;
 
             const relative = path.relative(
                 options.baseDirectory,
@@ -312,8 +380,8 @@ export async function translateDirectoryDiff(
                 toUpdateJSONs[language] = {};
             }
 
-            for (const key in flatJSON) {
-                if (Object.prototype.hasOwnProperty.call(flatJSON, key)) {
+            for (const key in flat) {
+                if (Object.prototype.hasOwnProperty.call(flat, key)) {
                     toUpdateJSONs[language][
                         getTranslationDirectoryKey(
                             `${fullBasePath}/${file.replace(
@@ -323,7 +391,7 @@ export async function translateDirectoryDiff(
                             key,
                             options.inputLanguageCode,
                         )
-                    ] = flatJSON[key];
+                    ] = flat[key];
                 }
             }
         }
@@ -338,13 +406,17 @@ export async function translateDirectoryDiff(
         outputLanguage: string,
         flatOutputJSON: { [key: string]: string },
     ): void => {
-        const filesToJSON: {
-            [filePath: string]: { [key: string]: string };
-        } = {};
-
         const beforeBaseName = path.basename(
             path.resolve(options.baseDirectory, options.inputFolderNameBefore),
         );
+
+        // Regroup the flat compound-keyed output per source file. In diff
+        // mode translateDiff re-flattens, so each value is already a
+        // string keyed by the adapter's own flat key — no per-file
+        // unflatten is needed before handing it back to the adapter.
+        const filesToFlat: {
+            [beforePath: string]: { [key: string]: string };
+        } = {};
 
         for (const pathWithKey in flatOutputJSON) {
             if (
@@ -356,46 +428,49 @@ export async function translateDirectoryDiff(
                 continue;
             }
 
-            const filePath = pathWithKey
+            const beforePath = pathWithKey
                 .split(DIRECTORY_KEY_DELIMITER)
                 .slice(0, -1)
-                .join(DIRECTORY_KEY_DELIMITER)
-                .replace(`/${beforeBaseName}/`, `/${outputLanguage}/`);
+                .join(DIRECTORY_KEY_DELIMITER);
 
-            if (!filesToJSON[filePath]) filesToJSON[filePath] = {};
+            if (!filesToFlat[beforePath]) filesToFlat[beforePath] = {};
             const key = pathWithKey.split(DIRECTORY_KEY_DELIMITER).pop()!;
-            filesToJSON[filePath][key] = flatOutputJSON[pathWithKey];
+            filesToFlat[beforePath][key] = flatOutputJSON[pathWithKey];
         }
 
-        for (const perFileJSON in filesToJSON) {
-            if (
-                !Object.prototype.hasOwnProperty.call(filesToJSON, perFileJSON)
-            ) {
+        for (const beforePath in filesToFlat) {
+            if (!Object.prototype.hasOwnProperty.call(filesToFlat, beforePath)) {
                 continue;
             }
 
-            const unflattenedOutput = unflatten(filesToJSON[perFileJSON], {
-                delimiter: FLATTEN_DELIMITER,
-            });
+            const meta = fileAdapters[beforePath];
+            if (!meta) continue;
 
-            const outputText = JSON.stringify(unflattenedOutput, null, 4);
+            const outputFilePath = beforePath.replace(
+                `/${beforeBaseName}/`,
+                `/${outputLanguage}/`,
+            );
+
+            const outputText = meta.adapter.write(
+                filesToFlat[beforePath],
+                meta.sidecar,
+                inputLanguage,
+                outputLanguage,
+            );
 
             if (!options.dryRun) {
-                fs.mkdirSync(dirname(perFileJSON), { recursive: true });
-                fs.writeFileSync(perFileJSON, `${outputText}\n`);
+                fs.mkdirSync(dirname(outputFilePath), { recursive: true });
+                fs.writeFileSync(outputFilePath, outputText);
             } else {
-                // TODO: find a cleaner way to get the input file from here
-                // Might lead to a bug if the path has the language code multiple times
                 const relativeOutputPath = path.relative(
                     options.baseDirectory,
-                    perFileJSON.replace(
-                        `/${inputLanguage}/`,
-                        `/${outputLanguage}/`,
-                    ),
+                    outputFilePath,
                 );
 
-                const input = fs.readFileSync(perFileJSON, "utf-8");
-                const translationDiff = diffJson(input, outputText);
+                const rawBefore = fs.existsSync(outputFilePath)
+                    ? fs.readFileSync(outputFilePath, "utf-8")
+                    : "";
+
                 fs.mkdirSync(
                     dirname(`${options.dryRun.basePath}/${relativeOutputPath}`),
                     { recursive: true },
@@ -407,11 +482,8 @@ export async function translateDirectoryDiff(
                 );
 
                 const patch = createPatch(
-                    perFileJSON.replace(
-                        `/${inputLanguage}/`,
-                        `/${outputLanguage}/`,
-                    ), // Use the absolute path for the patch header
-                    input,
+                    outputFilePath, // Use the absolute path for the patch header
+                    rawBefore,
                     outputText,
                 );
 
@@ -421,13 +493,21 @@ export async function translateDirectoryDiff(
                 );
 
                 printInfo(
-                    `Wrote new JSON to ${options.dryRun.basePath}/${relativeOutputPath}`,
+                    `Wrote new ${meta.adapter.name} to ${options.dryRun.basePath}/${relativeOutputPath}`,
                 );
 
                 printInfo(
                     `Wrote patch to ${options.dryRun.basePath}/${relativeOutputPath}.patch`,
                 );
-                if (options.verbose) {
+
+                // Colored inline diff is JSON-aware; other adapters still
+                // emit the patch file but skip the terminal diff.
+                if (
+                    options.verbose &&
+                    meta.adapter.name === "json" &&
+                    rawBefore
+                ) {
+                    const translationDiff = diffJson(rawBefore, outputText);
                     for (const part of translationDiff) {
                         const colorFns = {
                             green: colors.green,

--- a/src/translate_file.ts
+++ b/src/translate_file.ts
@@ -1,4 +1,10 @@
+import { FLATTEN_DELIMITER } from "./constants";
 import { createPatch, diffJson } from "diff";
+import { flatten, unflatten } from "flat";
+import {
+    getAdapterByName,
+    getAdapterForFile,
+} from "./formats/registry";
 import {
     getLanguageCodeFromFilename,
     isValidLanguageCode,
@@ -21,12 +27,29 @@ import type TranslateFileOptions from "./interfaces/translate_file_options";
 export async function translateFile(
     options: TranslateFileOptions,
 ): Promise<void> {
-    let inputJSON = {};
+    const adapter = options.format
+        ? getAdapterByName(options.format)
+        : getAdapterForFile(options.inputFilePath);
+
+    if (!adapter) {
+        printError(`Unknown format: ${options.format}`);
+        return;
+    }
+
+    let rawInput: string;
     try {
-        const inputFile = fs.readFileSync(options.inputFilePath, "utf-8");
-        inputJSON = JSON.parse(inputFile);
+        rawInput = fs.readFileSync(options.inputFilePath, "utf-8");
     } catch (e) {
-        printError(`Invalid input JSON: ${e}`);
+        printError(`Failed to read input file: ${e}`);
+        return;
+    }
+
+    let flatInput: Record<string, string>;
+    let sidecar: unknown;
+    try {
+        ({ flat: flatInput, sidecar } = adapter.read(rawInput));
+    } catch (e) {
+        printError(`Invalid input (${adapter.name}): ${e}`);
         return;
     }
 
@@ -41,24 +64,36 @@ export async function translateFile(
     try {
         const outputJSON = await translate({
             ...options,
-            inputJSON,
+            inputJSON: flatInput,
             inputLanguageCode: inputLanguage,
             outputLanguageCode: outputLanguage,
         });
 
-        const outputText = JSON.stringify(outputJSON, null, 4);
+        // translate() returns an unflattened object; the adapter
+        // contract takes a flat map. Re-flattening is cheap and keeps
+        // the adapter agnostic of the pipeline's internal shape.
+        const flatOutput = flatten(outputJSON, {
+            delimiter: FLATTEN_DELIMITER,
+        }) as Record<string, string>;
+
+        const outputText = adapter.write(
+            flatOutput,
+            sidecar,
+            inputLanguage,
+            outputLanguage,
+        );
+
         if (!options.dryRun) {
-            fs.writeFileSync(options.outputFilePath, `${outputText}\n`);
+            fs.writeFileSync(options.outputFilePath, outputText);
         } else {
-            const translationDiff = diffJson(inputJSON, outputJSON);
             fs.writeFileSync(
-                `${options.dryRun.basePath}/${path.basename(options.outputFilePath)}.new.json`,
+                `${options.dryRun.basePath}/${path.basename(options.outputFilePath)}.new.${adapter.name}`,
                 outputText,
             );
 
             const patch = createPatch(
                 options.outputFilePath,
-                JSON.stringify(inputJSON, null, 4),
+                rawInput,
                 outputText,
             );
 
@@ -68,13 +103,25 @@ export async function translateFile(
             );
 
             printInfo(
-                `Wrote new JSON to ${options.dryRun.basePath}/${path.basename(options.outputFilePath)}.new.json`,
+                `Wrote new ${adapter.name} to ${options.dryRun.basePath}/${path.basename(options.outputFilePath)}.new.${adapter.name}`,
             );
 
             printInfo(
                 `Wrote patch to ${options.dryRun.basePath}/${path.basename(options.outputFilePath)}.patch`,
             );
-            if (options.verbose) {
+
+            // Colored inline diff is JSON-aware today; future adapters
+            // can bring their own formatter if this limits them.
+            if (options.verbose && adapter.name === "json") {
+                const unflattenedOutput = unflatten(flatOutput, {
+                    delimiter: FLATTEN_DELIMITER,
+                }) as object;
+
+                const translationDiff = diffJson(
+                    JSON.parse(rawInput),
+                    unflattenedOutput,
+                );
+
                 for (const part of translationDiff) {
                     const colorFns = {
                         green: colors.green,

--- a/src/translate_file.ts
+++ b/src/translate_file.ts
@@ -161,11 +161,24 @@ export async function translateFile(
 export async function translateFileDiff(
     options: TranslateFileDiffOptions,
 ): Promise<void> {
-    // Get all the *json files from the same path as beforeInputPath
+    const adapter = options.format
+        ? getAdapterByName(options.format)
+        : getAdapterForFile(options.inputBeforeFileOrPath);
+
+    if (!adapter) {
+        printError(`Unknown format: ${options.format}`);
+        return;
+    }
+
+    // Sibling target files share the source's format/extension.
     const excludeSet = new Set<string>(options.excludeLanguages ?? []);
     const outputFilesOrPaths = fs
         .readdirSync(path.dirname(options.inputBeforeFileOrPath))
-        .filter((file: string) => file.endsWith(".json"))
+        .filter((file: string) =>
+            adapter.extensions.some((ext) =>
+                file.toLowerCase().endsWith(ext.toLowerCase()),
+            ),
+        )
         .filter(
             (file) =>
                 file !== path.basename(options.inputBeforeFileOrPath) &&
@@ -187,20 +200,39 @@ export async function translateFileDiff(
 
     const outputPaths = outputFilesOrPaths.map(resolveInputPath);
 
-    let inputBeforeJSON = {};
-    let inputAfterJSON = {};
+    // Read both source revisions through the adapter. The *after*
+    // sidecar is the catalogue we rebuild every target file from, so it
+    // carries the current comments/structure/headers.
+    let inputBeforeFlat: Record<string, string>;
+    let inputAfterFlat: Record<string, string>;
+    let afterSidecar: unknown;
     try {
-        let inputFile = fs.readFileSync(inputBeforePath, "utf-8");
-        inputBeforeJSON = JSON.parse(inputFile);
-        inputFile = fs.readFileSync(inputAfterPath, "utf-8");
-        inputAfterJSON = JSON.parse(inputFile);
+        inputBeforeFlat = adapter.read(
+            fs.readFileSync(inputBeforePath, "utf-8"),
+        ).flat;
+        const afterRead = adapter.read(
+            fs.readFileSync(inputAfterPath, "utf-8"),
+        );
+
+        inputAfterFlat = afterRead.flat;
+        afterSidecar = afterRead.sidecar;
     } catch (e) {
-        printError(`Invalid input JSON: ${e}`);
+        printError(`Invalid input (${adapter.name}): ${e}`);
         return;
     }
 
+    // Existing target files are read with readTranslated when the format
+    // distinguishes source from target (PO: msgstr vs msgid); formats
+    // that don't (JSON) fall back to read.
+    const readTarget = (raw: string): Record<string, string> =>
+        adapter.readTranslated
+            ? adapter.readTranslated(raw).flat
+            : adapter.read(raw).flat;
+
     const toUpdateJSONs: { [language: string]: Object } = {};
     const languageCodeToOutputPath: { [language: string]: string } = {};
+    // Raw target contents retained for dry-run patch/diff "before" text.
+    const rawTargetByLanguage: { [language: string]: string } = {};
     // Validate every target locale up front so a bad code fails fast
     // before the first API call, instead of aborting mid-batch after
     // some locales have already incurred cost.
@@ -216,11 +248,12 @@ export async function translateFileDiff(
         }
 
         try {
-            const outputFile = fs.readFileSync(outputPath, "utf-8");
-            toUpdateJSONs[languageCode] = JSON.parse(outputFile);
+            const raw = fs.readFileSync(outputPath, "utf-8");
+            toUpdateJSONs[languageCode] = readTarget(raw);
             languageCodeToOutputPath[languageCode] = outputPath;
+            rawTargetByLanguage[languageCode] = raw;
         } catch (e) {
-            printError(`Invalid output JSON: ${e}`);
+            printError(`Invalid output (${adapter.name}): ${e}`);
         }
     }
 
@@ -230,92 +263,104 @@ export async function translateFileDiff(
         );
     }
 
+    // Write (or, for dry-run, emit artifacts for) one finished language.
+    const writeTarget = (
+        languageCode: string,
+        flatMap: Record<string, string>,
+    ): void => {
+        const outputPath = languageCodeToOutputPath[languageCode];
+        if (!outputPath) return;
+
+        const outputText = adapter.write(
+            flatMap,
+            afterSidecar,
+            options.inputLanguageCode,
+            languageCode,
+        );
+
+        if (!options.dryRun) {
+            fs.writeFileSync(outputPath, outputText);
+            return;
+        }
+
+        const rawBefore = rawTargetByLanguage[languageCode] ?? "";
+
+        fs.writeFileSync(
+            `${options.dryRun.basePath}/${path.basename(outputPath)}.new.${adapter.name}`,
+            outputText,
+        );
+
+        const patch = createPatch(outputPath, rawBefore, outputText);
+        fs.writeFileSync(
+            `${options.dryRun.basePath}/${path.basename(outputPath)}.patch`,
+            patch,
+        );
+
+        printInfo(
+            `Wrote new ${adapter.name} to ${options.dryRun.basePath}/${path.basename(outputPath)}.new.${adapter.name}`,
+        );
+
+        printInfo(
+            `Wrote patch to ${options.dryRun.basePath}/${path.basename(outputPath)}.patch`,
+        );
+
+        if (options.verbose && adapter.name === "json") {
+            const translationDiff = diffJson(
+                rawBefore ? JSON.parse(rawBefore) : {},
+                unflatten(flatMap, { delimiter: FLATTEN_DELIMITER }) as object,
+            );
+
+            for (const part of translationDiff) {
+                const colorFns = {
+                    green: colors.green,
+                    grey: colors.grey,
+                    red: colors.red,
+                } as const;
+
+                type ColorKey = keyof typeof colorFns;
+
+                let color: ColorKey;
+
+                if (part.added) {
+                    color = "green";
+                } else if (part.removed) {
+                    color = "red";
+                } else {
+                    color = "grey";
+                }
+
+                process.stderr.write(colorFns[color](part.value));
+            }
+
+            console.log();
+        }
+    };
+
     try {
         const outputJSON = await translateDiff({
             ...options,
-            inputJSONAfter: inputAfterJSON,
-            inputJSONBefore: inputBeforeJSON,
+            inputJSONAfter: inputAfterFlat,
+            inputJSONBefore: inputBeforeFlat,
             // Persist each locale as soon as it finishes so a crash
             // later in the run doesn't discard already-translated work.
-            // Dry-run output is still emitted below in aggregate.
+            // Dry-run output is emitted below in aggregate instead.
             onLanguageComplete: options.dryRun
                 ? undefined
-                : (languageCode, translated) => {
-                      const outputPath = languageCodeToOutputPath[languageCode];
-                      if (!outputPath) return;
-                      const text = JSON.stringify(translated, null, 4);
-                      fs.writeFileSync(outputPath, `${text}\n`);
-                  },
+                : (languageCode, _unflattened, flat) =>
+                      writeTarget(languageCode, flat),
             toUpdateJSONs,
         });
 
-        for (const language in outputJSON) {
-            if (Object.prototype.hasOwnProperty.call(outputJSON, language)) {
-                const outputText = JSON.stringify(
-                    outputJSON[language],
-                    null,
-                    4,
-                );
+        if (options.dryRun) {
+            for (const language in outputJSON) {
+                if (
+                    Object.prototype.hasOwnProperty.call(outputJSON, language)
+                ) {
+                    const flatMap = flatten(outputJSON[language], {
+                        delimiter: FLATTEN_DELIMITER,
+                    }) as Record<string, string>;
 
-                const inputJSON = toUpdateJSONs[language];
-                const outputPath = languageCodeToOutputPath[language];
-
-                if (!options.dryRun) {
-                    // Already persisted in onLanguageComplete above.
-                } else {
-                    const translationDiff = diffJson(
-                        inputJSON,
-                        outputJSON[language],
-                    );
-
-                    fs.writeFileSync(
-                        `${options.dryRun.basePath}/${path.basename(outputPath)}.new.json`,
-                        outputText,
-                    );
-
-                    const patch = createPatch(
-                        outputPath,
-                        JSON.stringify(inputJSON, null, 4),
-                        outputText,
-                    );
-
-                    fs.writeFileSync(
-                        `${options.dryRun.basePath}/${path.basename(outputPath)}.patch`,
-                        patch,
-                    );
-
-                    printInfo(
-                        `Wrote new JSON to ${options.dryRun.basePath}/${path.basename(outputPath)}.new.json`,
-                    );
-
-                    printInfo(
-                        `Wrote patch to ${options.dryRun.basePath}/${path.basename(outputPath)}.patch`,
-                    );
-                    if (options.verbose) {
-                        for (const part of translationDiff) {
-                            const colorFns = {
-                                green: colors.green,
-                                grey: colors.grey,
-                                red: colors.red,
-                            } as const;
-
-                            type ColorKey = keyof typeof colorFns;
-
-                            let color: ColorKey;
-
-                            if (part.added) {
-                                color = "green";
-                            } else if (part.removed) {
-                                color = "red";
-                            } else {
-                                color = "grey";
-                            }
-
-                            process.stderr.write(colorFns[color](part.value));
-                        }
-
-                        console.log();
-                    }
+                    writeTarget(language, flatMap);
                 }
             }
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -171,6 +171,31 @@ export function getAllFilesInPath(directory: string): Array<string> {
 export const DIRECTORY_KEY_DELIMITER = "\x1f";
 
 /**
+ * Swap the input-language segment of a source file path for the output
+ * language, normalising separators. This is the path half of
+ * {@link getTranslationDirectoryKey}; the directory wrappers key
+ * per-file adapter state (sidecar, chosen adapter) by it so the write
+ * loop can recover that state after translation. Normalizing to forward
+ * slashes keeps the language-segment match working on Windows (where
+ * path.resolve returns backslash paths) and POSIX alike.
+ * @param sourceFilePath - the source file's path
+ * @param inputLanguageCode - the source language code
+ * @param outputLanguageCode - the target language code (defaults to input)
+ * @returns the output file path with forward slashes
+ */
+export function getTranslationDirectoryPath(
+    sourceFilePath: string,
+    inputLanguageCode: string,
+    outputLanguageCode?: string,
+): string {
+    const normalized = sourceFilePath.replace(/\\/g, "/");
+    return normalized.replace(
+        `/${inputLanguageCode}/`,
+        `/${outputLanguageCode ?? inputLanguageCode}/`,
+    );
+}
+
+/**
  * @param sourceFilePath - the source file's path
  * @param key - the key associated with the translation
  * @param inputLanguageCode - the language code of the source language
@@ -184,15 +209,10 @@ export function getTranslationDirectoryKey(
     inputLanguageCode: string,
     outputLanguageCode?: string,
 ): string {
-    // Normalize to forward slashes for the language-segment match so
-    // the swap works on Windows (where path.resolve returns backslash
-    // paths) and POSIX alike. Callers treat the returned string as an
-    // opaque compound key; consumers that split on DIRECTORY_KEY_DELIMITER
-    // use path utilities rather than depending on separator style.
-    const normalized = sourceFilePath.replace(/\\/g, "/");
-    const outputPath = normalized.replace(
-        `/${inputLanguageCode}/`,
-        `/${outputLanguageCode ?? inputLanguageCode}/`,
+    const outputPath = getTranslationDirectoryPath(
+        sourceFilePath,
+        inputLanguageCode,
+        outputLanguageCode,
     );
 
     return `${outputPath}${DIRECTORY_KEY_DELIMITER}${key}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -954,6 +954,13 @@
   resolved "https://registry.npmjs.org/@types/flat/-/flat-5.0.5.tgz"
   integrity sha512-nPLljZQKSnac53KDUDzuzdRfGI0TDb5qPrb+SrQyN3MtdQrOnGsKniHN1iYZsJEBIVQve94Y6gNz22sgISZq+Q==
 
+"@types/gettext-parser@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@types/gettext-parser/-/gettext-parser-9.0.0.tgz#d51cd2bac1894a6a2a263e4e44fd15b3cf7b54f8"
+  integrity sha512-LpZ+LeNa/tiFTxouKLkoyXVFF7JChu32YcZfnu+k54NfmlwlIiR017o3r+2yyB1FLg6LDzbF/UyH+AfhqffmXA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.1", "@types/istanbul-lib-coverage@^2.0.6":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
@@ -1202,6 +1209,13 @@
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.10.1.tgz#a8671852030a37d886d4faf81f06de1885df3271"
   integrity sha512-2v3erKKmmCyIVvvhI2nF15qEbdBpISTq44m9pyd5gfIJB1PN94oePTLWEd82XUbIbvKhv76xTSeUQSCOGesLeg==
+
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
 
 acorn-jsx@^5.2.0, acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -1479,7 +1493,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.5.1:
+base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -1534,6 +1548,14 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
@@ -1670,6 +1692,11 @@ confusing-browser-globals@^1.0.10:
   version "1.0.11"
   resolved "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz"
   integrity sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==
+
+content-type@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
+  integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
 
 convert-source-map@^2.0.0:
   version "2.0.0"
@@ -1855,6 +1882,13 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+encoding@^0.1.13:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
+  integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
+  dependencies:
+    iconv-lite "^0.6.2"
 
 enhanced-resolve@^5.17.1:
   version "5.17.1"
@@ -2386,6 +2420,16 @@ esutils@^2.0.2:
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
 execa@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
@@ -2673,6 +2717,16 @@ get-tsconfig@^4.8.1:
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
+gettext-parser@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/gettext-parser/-/gettext-parser-7.0.1.tgz#1d0308b6d7b0ac2250cafddb988d03ce170c2a3b"
+  integrity sha512-LU+ieGH3L9HmKEArTlX816/iiAlyA0fx/n/QSeQpkAaH/+jxMk/5UtDkAzcVvW+KlY25/U+IE6dnfkJ8ynt8pQ==
+  dependencies:
+    content-type "^1.0.5"
+    encoding "^0.1.13"
+    readable-stream "^4.3.0"
+    safe-buffer "^5.2.1"
+
 glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
@@ -2849,6 +2903,18 @@ human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
+iconv-lite@^0.6.2:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^5.2.0, ignore@^5.3.1, ignore@^5.3.2:
   version "5.3.2"
@@ -4232,6 +4298,11 @@ pretty-format@30.2.0:
     ansi-styles "^5.2.0"
     react-is "^18.3.1"
 
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
+
 punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
@@ -4251,6 +4322,17 @@ react-is@^18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+readable-stream@^4.3.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.7.0.tgz#cedbd8a1146c13dfff8dab14068028d58c15ac91"
+  integrity sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==
+  dependencies:
+    abort-controller "^3.0.0"
+    buffer "^6.0.3"
+    events "^3.3.0"
+    process "^0.11.10"
+    string_decoder "^1.3.0"
 
 reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
   version "1.0.10"
@@ -4379,6 +4461,11 @@ safe-array-concat@^1.1.3:
     has-symbols "^1.1.0"
     isarray "^2.0.5"
 
+safe-buffer@^5.2.1, safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 safe-push-apply@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/safe-push-apply/-/safe-push-apply-1.0.0.tgz#01850e981c1602d398c85081f360e4e6d03d27f5"
@@ -4404,6 +4491,11 @@ safe-regex-test@^1.1.0:
     call-bound "^1.0.2"
     es-errors "^1.3.0"
     is-regex "^1.2.1"
+
+"safer-buffer@>= 2.1.2 < 3.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
@@ -4582,16 +4674,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4650,6 +4733,13 @@ string.prototype.trimstart@^1.0.8:
     call-bind "^1.0.7"
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
+
+string_decoder@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
@@ -5115,16 +5205,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## What

Adds a format-adapter abstraction so the translation pipeline can speak file formats beyond i18next JSON, and ships **Gettext `.po`** as the first new format. JSON behavior is unchanged — it's now just one adapter among others.

## Why

The pipeline's internal contract is already a flat `{ [key: string]: string }` map, which is the lowest common denominator across every i18n format. Rather than forking the pipeline per format, each format owns an adapter that:

1. parses its file into that flat map,
2. normalizes native placeholders (`%s`, `%1$s`, …) to the project's `{{argN}}` convention,
3. carries everything the pipeline doesn't need to see (comments, `msgctxt`, ordering, plural counts, original placeholder syntax) in an opaque **sidecar**, and
4. writes the translated map + sidecar back out so untouched keys round-trip intact.

A naive "convert to JSON, translate, convert back" would drop developer comments and `msgctxt` — a round-trip that loses those fails review. The sidecar avoids that.

## How

- **`FormatAdapter<TSidecar>`** (`src/formats/format_adapter.ts`) — generic over a private per-format sidecar type, type-erased at the registry boundary so the dispatcher holds `FormatAdapter<unknown>[]` without unsafe casts.
- **Registry** (`src/formats/registry.ts`) — resolves an adapter by `--file-format` name or by file extension, falling back to JSON.
- **`JSONAdapter`** — byte-for-byte identical to today's `JSON.stringify(…, 4)` + trailing newline.
- **`POAdapter`** — `gettext-parser`-backed. `msgctxt` folds into the flat key (`ctx\x1emsgid`); plurals expand to `_one`/`_other` on read and fan back into the target language's `msgstr[]` via a hard-coded CLDR plural table (`po_plural_rules.ts`); printf placeholders are stripped to `{{argN}}` and restored on write.
- **All four wrappers migrated** — `translateFile`, `translateFileDiff`, `translateDirectory`, and `translateDirectoryDiff` route through the registry, so any registered format works on every surface (not just single-file translate).
- **Diff target preservation** — a new optional `FormatAdapter.readTranslated` hook lets formats that separate source from target (PO: `msgstr` vs `msgid`) read existing translations so unchanged keys survive a diff; JSON falls back to `read`.
- **CLI** — new `--file-format json|po` flag on `translate` and `diff` (named to avoid colliding with `check`'s existing `--format` report-output flag).

## Notes / limitations

- `gettext-parser` is pinned to **`7.0.1`** — v8+ is ESM-only and breaks the CommonJS build/test setup.
- Languages with >2 plural forms clone the `_other` slot into every non-`one` category. This is the honest v1 behavior given i18next only marks two plural forms; a richer plural IR is deferred.
- **`check` mode is still JSON-only** — not migrated in this PR; a small follow-up using the same `adapter.read`.
- Next up (separate PRs): Phase 2 simple flat formats — `.properties`, `.strings`, Rails YAML.

## Testing

- New `src/test/formats.spec.ts` — registry resolution, `JSONAdapter` byte round-trip, and **22 PO tests** covering read/write, `msgctxt`, placeholder normalization (incl. `%%` escapes, width/precision, positional, and model-invented args), 2-/3-form plural fan-in/out, `readTranslated` index math, round-trip metadata fidelity, and graceful degradation on incomplete model output. `po_adapter.ts` is at 100% stmt/func/line coverage.
- New end-to-end PO tests in `src/test/translate.spec.ts` for all four wrappers against the mocked pipeline.
- Full suite: **165 passed**. Existing JSON tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)