### PR TITLE
Route check mode through the format registry for PO support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ i18n-ai-translate translate -i i18n/en.json -o fr \
 
 Need more languages? Pass multiple codes (`-o fr es de`) or `-A` for **all** 180+. Filenames like `es-ES.json` / `pt-BR.json` are accepted too — the language subtag is extracted automatically. Skip specific locales with `--exclude-languages fr de` (handy for locales you maintain by hand).
 
-**Other formats:** Gettext `.po` files work too — the format is inferred from the file extension (override with `--file-format json|po`). Comments, `msgctxt`, plural forms, and `printf` placeholders round-trip losslessly. Works across `translate` (file + folder) and `diff`.
+**Other formats:** Gettext `.po` files work too — the format is inferred from the file extension (override with `--file-format json|po`). Comments, `msgctxt`, plural forms, and `printf` placeholders round-trip losslessly. Works across `translate` (file + folder), `diff`, and `check`.
 
 ### 3 · Translate a folder
 
@@ -105,7 +105,7 @@ Common flags (all subcommands accept these unless noted):
 | `--exclude-languages`     | —               | Locales to skip (for manually‑maintained targets)                               |
 | `--no-continue-on-error`  | continue        | Abort on first key/batch failure instead of skipping                            |
 | `--dry-run`               | false           | Don't write files, preview instead (translate/diff only)                        |
-| `--file-format`           | from extension  | Input/output file format: `json` or `po` (translate/diff only)                  |
+| `--file-format`           | from extension  | Input/output file format: `json` or `po` (translate/diff/check)                 |
 | `--format`                | table           | `table` or `json` report output (check only)                                    |
 
 Full flag list: `i18n-ai-translate <subcommand> --help`.

--- a/src/cli_check.ts
+++ b/src/cli_check.ts
@@ -5,6 +5,7 @@ import {
 } from "./constants";
 import { Command } from "commander";
 import { check } from "./check";
+import { getAdapterByName, getAdapterForFile } from "./formats/registry";
 import {
     getLanguageCodeFromFilename,
     printError,
@@ -66,6 +67,7 @@ export default function buildCheckCommand(): Command {
             "Output format: 'table' (default, human-readable) or 'json' (for CI consumption)",
             "table",
         )
+        .option("--file-format <format>", CLI_HELP.FileFormat)
         .action(async (options: any) => {
             const modelArgs = processModelArgs(options);
 
@@ -101,22 +103,41 @@ export default function buildCheckCommand(): Command {
                 process.exit(2);
             }
 
-            const inputLanguageCode = getLanguageCodeFromFilename(inputPath);
-            const sourceJSON = JSON.parse(fs.readFileSync(inputPath, "utf-8"));
+            // Resolve the format adapter from --file-format, else infer
+            // it from the source extension (JSON by default).
+            const adapter = options.fileFormat
+                ? getAdapterByName(options.fileFormat)
+                : getAdapterForFile(inputPath);
 
-            // Determine which target files to check.
+            if (!adapter) {
+                printError(`Unknown format: ${options.fileFormat}`);
+                process.exit(2);
+            }
+
+            const inputLanguageCode = getLanguageCodeFromFilename(inputPath);
+            const sourceFlat = adapter.read(
+                fs.readFileSync(inputPath, "utf-8"),
+            ).flat;
+
+            // Determine which target files to check. Siblings are matched
+            // by the adapter's extension(s), not a hardcoded .json.
             const sourceDir = path.dirname(inputPath);
             const inputBase = path.basename(inputPath);
+            const targetExtension = adapter.extensions[0];
+            const matchesFormat = (file: string): boolean =>
+                adapter.extensions.some((ext) =>
+                    file.toLowerCase().endsWith(ext.toLowerCase()),
+                );
 
             let targetFiles: string[];
             if (options.targetLanguages && options.targetLanguages.length > 0) {
                 targetFiles = options.targetLanguages.map((code: string) =>
-                    path.join(sourceDir, `${code}.json`),
+                    path.join(sourceDir, `${code}${targetExtension}`),
                 );
             } else {
                 targetFiles = fs
                     .readdirSync(sourceDir)
-                    .filter((f) => f.endsWith(".json") && f !== inputBase)
+                    .filter((f) => matchesFormat(f) && f !== inputBase)
                     .map((f) => path.join(sourceDir, f));
             }
 
@@ -138,14 +159,18 @@ export default function buildCheckCommand(): Command {
                     path.basename(targetFile),
                 );
 
-                let targetJSON: Object;
+                let targetFlat: { [key: string]: string };
                 try {
-                    targetJSON = JSON.parse(
-                        fs.readFileSync(targetFile, "utf-8"),
-                    );
+                    const raw = fs.readFileSync(targetFile, "utf-8");
+                    // Formats that separate source from target (PO:
+                    // msgstr vs msgid) expose the translated values via
+                    // readTranslated, keyed identically to the source.
+                    targetFlat = adapter.readTranslated
+                        ? adapter.readTranslated(raw).flat
+                        : adapter.read(raw).flat;
                 } catch (e) {
                     printError(
-                        `Skipping invalid target JSON ${targetFile}: ${e}`,
+                        `Skipping unreadable target ${targetFile}: ${e}`,
                     );
                     continue;
                 }
@@ -161,13 +186,13 @@ export default function buildCheckCommand(): Command {
                     ...modelArgs,
                     context: options.context,
                     engine: options.engine,
-                    inputJSON: sourceJSON,
+                    inputJSON: sourceFlat,
                     inputLanguageCode,
                     outputLanguageCode,
                     overridePrompt,
                     pool: sharedPool,
                     rateLimiter: sharedRateLimiter,
-                    targetJSON,
+                    targetJSON: targetFlat,
                     templatedStringPrefix: options.templatedStringPrefix,
                     templatedStringSuffix: options.templatedStringSuffix,
                     verbose: options.verbose,

--- a/src/test/check.spec.ts
+++ b/src/test/check.spec.ts
@@ -89,8 +89,13 @@ import Engine_ from "../enums/engine";
 import PromptMode from "../enums/prompt_mode";
 // eslint-disable-next-line import/first
 import { check } from "../check";
+// eslint-disable-next-line import/first
+import POAdapter from "../formats/po_adapter";
 
 process.env.OPENAI_API_KEY = "test";
+
+// ASCII Record Separator — must match KEY_DELIMITER in po_adapter.ts.
+const SEP = "\x1e";
 
 const baseCheckOptions = {
     apiKey: "test",
@@ -137,8 +142,8 @@ describe("check mode", () => {
 
         const report = await check({
             ...baseCheckOptions,
-            inputJSON: { good: "Good", bad: "Bad_source" },
-            targetJSON: { good: "Bien", bad: "Bad" },
+            inputJSON: { bad: "Bad_source", good: "Good" },
+            targetJSON: { bad: "Bad", good: "Bien" },
         } as any);
 
         expect(report.issues).toHaveLength(1);
@@ -204,5 +209,86 @@ describe("check mode", () => {
         } as any);
 
         expect(report.issues.map((i) => i.key).sort()).toEqual(["k2", "k4"]);
+    });
+});
+
+// cli_check routes PO files through the adapter: the source is read via
+// `read` (keyed by msgid) and each target via `readTranslated` (keyed by
+// the same msgid, valued by msgstr). These tests feed check() the exact
+// flat maps that wiring produces, exercising the key-alignment contract.
+describe("check mode with PO adapter input", () => {
+    const sourcePO = [
+        "msgid \"\"",
+        "msgstr \"\"",
+        "\"Content-Type: text/plain; charset=UTF-8\\n\"",
+        "\"Language: en\\n\"",
+        "",
+        "msgid \"Hello\"",
+        "msgstr \"\"",
+        "",
+        "msgctxt \"menu\"",
+        "msgid \"Save\"",
+        "msgstr \"\"",
+        "",
+    ].join("\n");
+
+    const targetPO = (saveTranslation: string): string =>
+        [
+            "msgid \"\"",
+            "msgstr \"\"",
+            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
+            "\"Language: fr\\n\"",
+            "",
+            "msgid \"Hello\"",
+            "msgstr \"Bonjour\"",
+            "",
+            "msgctxt \"menu\"",
+            "msgid \"Save\"",
+            `msgstr "${saveTranslation}"`,
+            "",
+        ].join("\n");
+
+    it("aligns source msgid with target msgstr across the report", async () => {
+        const sourceFlat = POAdapter.read(sourcePO).flat;
+        const targetFlat = POAdapter.readTranslated!(targetPO("Sauvegarder"))
+            .flat;
+
+        const report = await check({
+            ...baseCheckOptions,
+            inputJSON: sourceFlat,
+            targetJSON: targetFlat,
+        } as any);
+
+        // Both entries are present and keyed by the adapter's msgid keys.
+        expect(report.totalKeys).toBe(2);
+        expect(report.issues).toEqual([]);
+    });
+
+    it("flags a bad msgstr against its source msgid", async () => {
+        // The verifier rejects the (deliberately wrong) Save translation.
+        verdicts.set("Sauvegarder_wrong", {
+            fixedTranslation: "Enregistrer",
+            issue: "wrong word for the menu action",
+            valid: false,
+        });
+
+        const sourceFlat = POAdapter.read(sourcePO).flat;
+        const targetFlat = POAdapter.readTranslated!(
+            targetPO("Sauvegarder_wrong"),
+        ).flat;
+
+        const report = await check({
+            ...baseCheckOptions,
+            inputJSON: sourceFlat,
+            targetJSON: targetFlat,
+        } as any);
+
+        expect(report.issues).toHaveLength(1);
+        expect(report.issues[0]).toMatchObject({
+            key: `menu${SEP}Save`,
+            original: "Save",
+            suggestion: "Enregistrer",
+            translated: "Sauvegarder_wrong",
+        });
     });
 });


### PR DESCRIPTION
## Summary

`check` was the last CLI surface still hardcoded to JSON — it called `JSON.parse` directly, so `.po` files silently failed verification even though `translate` and `diff` already routed through the format registry (#480). This wires `check` through the same adapters so PO translations can be audited end-to-end.

## What changed

- **`src/cli_check.ts`** — source and target files are now read through a resolved `FormatAdapter` instead of `JSON.parse`:
  - Adapter resolved from `--file-format json|po`, falling back to the source file's extension.
  - Source read via `adapter.read` (keyed by msgid for PO); each target read via `adapter.readTranslated` when available (PO's `msgstr`, keyed identically to the source) and `adapter.read` otherwise.
  - Sibling-target globbing matches the adapter's extension(s) rather than a hardcoded `.json`.
- **`README.md`** — PO note and the `--file-format` flag row now list `check` alongside `translate`/`diff`.

## Why `check()` itself is untouched

The exported `check()` still takes nested `Object` inputs and flattens internally with `FLATTEN_DELIMITER`. Flattening an already-flat string-valued map is idempotent (only keys are split/joined; values are untouched), so the adapter's flat map passes straight through. This keeps the public library signature backward-compatible — callers passing nested objects are unaffected.

PO's `read` (source, by msgid) and `readTranslated` (target, same msgid) produce identically-keyed maps, which is exactly the alignment the verifier needs.

## Tests

Two new tests in `src/test/check.spec.ts` drive `check()` with real PO adapter output:
- source msgid ↔ target msgstr align across a clean report
- a bad `msgstr` is flagged against its source msgid (`menu\x1eSave`)

Full suite: **167 passed** (+2). 0 lint errors, `tsc` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
