### PR TITLE
Add a glossary for terminology control

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Common flags (all subcommands accept these unless noted):
 | `--language-concurrency`  | 1               | Target languages to translate in parallel (shares pool + rate limit)            |
 | `--tokens-per-minute`     | off             | Extra TPM cap across all workers; pair with `--concurrency` to stay under tier  |
 | `--context <string>`      | —               | Product/domain context, e.g. `"a B2B invoicing SaaS"`                           |
+| `--glossary <path>`       | —               | JSON file: keep-verbatim terms + forced per-language translations               |
 | `--exclude-languages`     | —               | Locales to skip (for manually‑maintained targets)                               |
 | `--no-continue-on-error`  | continue        | Abort on first key/batch failure instead of skipping                            |
 | `--dry-run`               | false           | Don't write files, preview instead (translate/diff only)                        |
@@ -154,6 +155,7 @@ const report = await check({
 * **Prompt modes**: `csv` (faster, GPT‑class models only) vs `json` (structured output, works with weaker models too)
 * **Custom prompts**: swap in your own generation/verification prompts via `--override-prompt`
 * **Translation memory**: `--cache [path]` stores translations in a JSON file (default `.i18n-ai-translate-cache.json`) and reuses them on later runs, so unchanged strings are never re-sent to the model. The key is the source text + languages + `--context` — independent of engine/model, so the cache survives a provider switch. Library callers can pass their own `cache` object.
+* **Glossary**: `--glossary <path>` points to a JSON file that steers terminology — `doNotTranslate` keeps brand/product names verbatim, and `terms` forces exact per-language translations: `{ "doNotTranslate": ["Acme"], "terms": { "fr": { "Account": "Compte" } } }`. The rules are injected into both the generation and verification prompts; only the run's target language is applied (with BCP-47 base-subtag fallback, so `pt` covers `pt-BR`).
 * **Plural awareness**: keys ending in `_one`/`_other`/`_few`/`_many` get a CLDR plural hint in JSON mode
 * **Placeholders**: `{{variables}}` are preserved; customise delimiters with `-p`/`-s`
 * **Rate-limit handling**: per-engine defaults + exponential backoff; `--tokens-per-minute` adds TPM cap

--- a/src/cli_diff.ts
+++ b/src/cli_diff.ts
@@ -5,6 +5,7 @@ import {
 } from "./constants";
 import { Command } from "commander";
 import { DEFAULT_CACHE_PATH, loadCache, saveCache } from "./cache";
+import { loadGlossary } from "./glossary";
 import { printError, printInfo, resolveInputPath } from "./utils";
 import { processModelArgs, processOverridePromptFile } from "./cli_helpers";
 import { translateDirectoryDiff } from "./translate_directory";
@@ -15,6 +16,7 @@ import fs, { mkdtempSync } from "fs";
 import path from "path";
 import type { TranslationCache } from "./cache";
 import type DryRun from "./interfaces/dry_run";
+import type Glossary from "./interfaces/glossary";
 import type OverridePrompt from "./interfaces/override_prompt";
 
 /**
@@ -84,6 +86,7 @@ export default function buildDiffCommand(): Command {
         .option("--tokens-per-minute <tpm>", CLI_HELP.TokensPerMinute)
         .option("--file-format <format>", CLI_HELP.FileFormat)
         .option("--cache [path]", CLI_HELP.Cache)
+        .option("--glossary <path>", CLI_HELP.Glossary)
         .action(async (options: any) => {
             const modelArgs = processModelArgs(options);
 
@@ -120,6 +123,16 @@ export default function buildDiffCommand(): Command {
                 cache = loadCache(resolvedPath);
             }
 
+            let glossary: Glossary | undefined;
+            if (options.glossary) {
+                try {
+                    glossary = loadGlossary(options.glossary);
+                } catch (e) {
+                    printError(`${e}`);
+                    process.exit(2);
+                }
+            }
+
             const sharedOptions = {
                 ...modelArgs,
                 cache,
@@ -128,6 +141,7 @@ export default function buildDiffCommand(): Command {
                 ensureChangedTranslation: options.ensureChangedTranslation,
                 excludeLanguages: options.excludeLanguages,
                 format: options.fileFormat,
+                glossary,
                 pool: sharedPool,
                 rateLimiter: sharedRateLimiter,
                 skipStylingVerification: options.skipStylingVerification,

--- a/src/cli_translate.ts
+++ b/src/cli_translate.ts
@@ -5,6 +5,7 @@ import {
 } from "./constants";
 import { Command } from "commander";
 import { DEFAULT_CACHE_PATH, loadCache, saveCache } from "./cache";
+import { loadGlossary } from "./glossary";
 import {
     getAllLanguageCodes,
     getOutputPathFromInputPath,
@@ -24,6 +25,7 @@ import fs, { mkdtempSync } from "fs";
 import path from "path";
 import type { TranslationCache } from "./cache";
 import type DryRun from "./interfaces/dry_run";
+import type Glossary from "./interfaces/glossary";
 import type OverridePrompt from "./interfaces/override_prompt";
 
 /**
@@ -95,6 +97,7 @@ export default function buildTranslateCommand(): Command {
         .option("--language-concurrency <n>", CLI_HELP.LanguageConcurrency)
         .option("--file-format <format>", CLI_HELP.FileFormat)
         .option("--cache [path]", CLI_HELP.Cache)
+        .option("--glossary <path>", CLI_HELP.Glossary)
         .action(async (options: any) => {
             const modelArgs = processModelArgs(options);
             const languageConcurrency = Math.max(
@@ -137,6 +140,16 @@ export default function buildTranslateCommand(): Command {
                 cache = loadCache(resolvedPath);
             }
 
+            let glossary: Glossary | undefined;
+            if (options.glossary) {
+                try {
+                    glossary = loadGlossary(options.glossary);
+                } catch (e) {
+                    printError(`${e}`);
+                    process.exit(2);
+                }
+            }
+
             // The commander options object carries CLI-only booleans that
             // processModelArgs doesn't re-expose; forward them by spreading
             // the subset the translate*() wrappers actually consume.
@@ -148,6 +161,7 @@ export default function buildTranslateCommand(): Command {
                 ensureChangedTranslation: options.ensureChangedTranslation,
                 excludeLanguages: options.excludeLanguages,
                 format: options.fileFormat,
+                glossary,
                 pool: sharedPool,
                 rateLimiter: sharedRateLimiter,
                 skipStylingVerification: options.skipStylingVerification,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,6 +37,8 @@ export const CLI_HELP = {
         "Language codes to skip (e.g. 'fr de'). Useful when some locales are maintained manually and shouldn't be machine-translated over",
     FileFormat:
         "Input/output file format (default: inferred from extension). Supported: json, po, properties, strings.",
+    Glossary:
+        "Path to a glossary JSON file steering terminology: { \"doNotTranslate\": [\"Acme\"], \"terms\": { \"fr\": { \"Account\": \"Compte\" } } }. Injected into the generation and verification prompts",
     LanguageConcurrency:
         "How many target languages to translate in parallel (default 1). Each language shares the same pool and rate limiter, so raising this does not multiply provider traffic — pair with --concurrency and --tokens-per-minute to tune overall throughput.",
     MaxTokens: "The maximum token size of a request",

--- a/src/generate_csv/generate.ts
+++ b/src/generate_csv/generate.ts
@@ -34,6 +34,7 @@ async function generateTranslation(
         input,
         {
             context: options.context,
+            glossary: options.glossary,
             overridePrompt: options.overridePrompt,
         },
     );
@@ -138,6 +139,7 @@ async function runShard(
             context: options.context,
             ensureChangedTranslation:
                 options.ensureChangedTranslation as boolean,
+            glossary: options.glossary,
             input,
             inputLanguageCode: options.inputLanguageCode,
             keys,
@@ -372,6 +374,7 @@ async function generate(
             text,
             {
                 context: options.context,
+                glossary: options.glossary,
                 overridePrompt: options.overridePrompt,
             },
         );
@@ -401,6 +404,7 @@ async function generate(
             text,
             {
                 context: options.context,
+                glossary: options.glossary,
                 overridePrompt: options.overridePrompt,
             },
         );

--- a/src/generate_csv/prompts.ts
+++ b/src/generate_csv/prompts.ts
@@ -1,4 +1,6 @@
+import { buildGlossaryInstructions } from "../glossary";
 import { getLanguageName } from "../utils";
+import type Glossary from "../interfaces/glossary";
 import type OverridePrompt from "../interfaces/override_prompt";
 
 function buildContextPreamble(context?: string): string {
@@ -21,6 +23,7 @@ export function generationPrompt(
     options?: {
         overridePrompt?: OverridePrompt;
         context?: string;
+        glossary?: Glossary;
     },
 ): string {
     const inputLanguage = getLanguageName(inputLanguageCode);
@@ -37,6 +40,10 @@ export function generationPrompt(
 
         const argumentToValue: { [key: string]: string } = {
             context: options?.context ?? "",
+            glossary: buildGlossaryInstructions(
+                options?.glossary,
+                outputLanguageCode,
+            ),
             input,
             inputLanguage,
             outputLanguage,
@@ -48,8 +55,12 @@ export function generationPrompt(
     }
 
     const contextPreamble = buildContextPreamble(options?.context);
+    const glossaryBlock = buildGlossaryInstructions(
+        options?.glossary,
+        outputLanguageCode,
+    );
 
-    return `${contextPreamble}You are a professional translator.
+    return `${contextPreamble}${glossaryBlock}You are a professional translator.
 
 Translate each line from ${inputLanguage} to ${outputLanguage}.
 
@@ -127,6 +138,7 @@ export function translationVerificationPrompt(
     options?: {
         overridePrompt?: OverridePrompt;
         context?: string;
+        glossary?: Glossary;
     },
 ): string {
     const inputLanguage = getLanguageName(inputLanguageCode);
@@ -152,6 +164,10 @@ export function translationVerificationPrompt(
 
         const argumentToValue: { [key: string]: string } = {
             context: options?.context ?? "",
+            glossary: buildGlossaryInstructions(
+                options?.glossary,
+                outputLanguageCode,
+            ),
             inputLanguage,
             mergedCSV,
             outputLanguage,
@@ -163,8 +179,12 @@ export function translationVerificationPrompt(
     }
 
     const contextPreamble = buildContextPreamble(options?.context);
+    const glossaryBlock = buildGlossaryInstructions(
+        options?.glossary,
+        outputLanguageCode,
+    );
 
-    return `${contextPreamble}You are a translation reviewer checking a ${inputLanguage}-to-${outputLanguage} batch in CSV form.
+    return `${contextPreamble}${glossaryBlock}You are a translation reviewer checking a ${inputLanguage}-to-${outputLanguage} batch in CSV form.
 
 Reply with NAK if ANY translation has a problem, including:
 - Inaccurate meaning, wrong tone, or grammar errors

--- a/src/generate_csv/verify.ts
+++ b/src/generate_csv/verify.ts
@@ -4,6 +4,7 @@ import {
     translationVerificationPrompt,
 } from "./prompts";
 import type ChatInterface from "../chats/chat_interface";
+import type Glossary from "../interfaces/glossary";
 import type OverridePrompt from "../interfaces/override_prompt";
 
 /**
@@ -24,6 +25,7 @@ export async function verifyTranslation(
     options?: {
         overridePrompt?: OverridePrompt;
         context?: string;
+        glossary?: Glossary;
     },
 ): Promise<string> {
     const translationVerificationPromptText = translationVerificationPrompt(
@@ -56,6 +58,7 @@ export async function verifyStyling(
     options?: {
         overridePrompt?: OverridePrompt;
         context?: string;
+        glossary?: Glossary;
     },
 ): Promise<string> {
     const stylingVerificationPromptText = stylingVerificationPrompt(

--- a/src/generate_json/generate.ts
+++ b/src/generate_json/generate.ts
@@ -181,6 +181,7 @@ export default class GenerateTranslationJSON {
                 this.generateVerifyItemsInput(batch),
                 {
                     context: options.context,
+                    glossary: options.glossary,
                     overridePrompt: options.overridePrompt,
                     templatedStringPrefix: options.templatedStringPrefix,
                     templatedStringSuffix: options.templatedStringSuffix,
@@ -297,6 +298,7 @@ export default class GenerateTranslationJSON {
                 [],
                 {
                     context: options.context,
+                    glossary: options.glossary,
                     overridePrompt: options.overridePrompt,
                     templatedStringPrefix: options.templatedStringPrefix,
                     templatedStringSuffix: options.templatedStringSuffix,
@@ -350,6 +352,7 @@ export default class GenerateTranslationJSON {
                 [],
                 {
                     context: options.context,
+                    glossary: options.glossary,
                     overridePrompt: options.overridePrompt,
                     templatedStringPrefix: options.templatedStringPrefix,
                     templatedStringSuffix: options.templatedStringSuffix,
@@ -480,6 +483,7 @@ export default class GenerateTranslationJSON {
                 context: options.context,
                 ensureChangedTranslation:
                     options.ensureChangedTranslation as boolean,
+                glossary: options.glossary,
                 inputLanguageCode: options.inputLanguageCode,
                 outputLanguageCode: options.outputLanguageCode,
                 overridePrompt: options.overridePrompt,
@@ -608,6 +612,7 @@ export default class GenerateTranslationJSON {
                 context: options.context,
                 ensureChangedTranslation:
                     options.ensureChangedTranslation as boolean,
+                glossary: options.glossary,
                 inputLanguageCode: options.inputLanguageCode,
                 outputLanguageCode: options.outputLanguageCode,
                 overridePrompt: options.overridePrompt,
@@ -836,6 +841,7 @@ export default class GenerateTranslationJSON {
             this.generateTranslateItemsInput(options.translateItems),
             {
                 context: options.context,
+                glossary: options.glossary,
                 keys: options.translateItems.map((it) => it.key),
                 overridePrompt: options.overridePrompt,
                 templatedStringPrefix: options.templatedStringPrefix,
@@ -889,6 +895,7 @@ export default class GenerateTranslationJSON {
             this.generateVerifyItemsInput(options.translateItems),
             {
                 context: options.context,
+                glossary: options.glossary,
                 overridePrompt: options.overridePrompt,
                 templatedStringPrefix: options.templatedStringPrefix,
                 templatedStringSuffix: options.templatedStringSuffix,

--- a/src/generate_json/prompts.ts
+++ b/src/generate_json/prompts.ts
@@ -1,5 +1,7 @@
+import { buildGlossaryInstructions } from "../glossary";
 import { getLanguageName } from "../utils";
 import type { TranslateItemInput, VerifyItemInput } from "./types";
+import type Glossary from "../interfaces/glossary";
 import type OverridePrompt from "../interfaces/override_prompt";
 
 // CLDR plural suffixes used by i18next keys. When a key ends in one of
@@ -42,6 +44,7 @@ export function translationPromptJSON(
     options?: {
         overridePrompt?: OverridePrompt;
         context?: string;
+        glossary?: Glossary;
         templatedStringPrefix?: string;
         templatedStringSuffix?: string;
         keys?: string[];
@@ -62,6 +65,10 @@ export function translationPromptJSON(
 
         const argumentToValue: { [key: string]: string } = {
             context: options?.context ?? "",
+            glossary: buildGlossaryInstructions(
+                options?.glossary,
+                outputLanguageCode,
+            ),
             input,
             inputLanguage,
             outputLanguage,
@@ -75,10 +82,15 @@ export function translationPromptJSON(
     const prefix = options?.templatedStringPrefix ?? "{{";
     const suffix = options?.templatedStringSuffix ?? "}}";
     const contextPreamble = buildContextPreamble(options?.context);
+    const glossaryBlock = buildGlossaryInstructions(
+        options?.glossary,
+        outputLanguageCode,
+    );
+
     const plural = pluralHint(options?.keys);
     const placeholderLine = buildPlaceholderLine(prefix, suffix);
 
-    return `${contextPreamble}You are a professional translator.
+    return `${contextPreamble}${glossaryBlock}You are a professional translator.
 
 Translate from ${inputLanguage} to ${outputLanguage}.
 
@@ -116,6 +128,7 @@ export function verificationPromptJSON(
     options?: {
         overridePrompt?: OverridePrompt;
         context?: string;
+        glossary?: Glossary;
         templatedStringPrefix?: string;
         templatedStringSuffix?: string;
     },
@@ -135,6 +148,10 @@ export function verificationPromptJSON(
 
         const argumentToValue: { [key: string]: string } = {
             context: options?.context ?? "",
+            glossary: buildGlossaryInstructions(
+                options?.glossary,
+                outputLanguageCode,
+            ),
             input,
             inputLanguage,
             outputLanguage,
@@ -148,9 +165,14 @@ export function verificationPromptJSON(
     const prefix = options?.templatedStringPrefix ?? "{{";
     const suffix = options?.templatedStringSuffix ?? "}}";
     const contextPreamble = buildContextPreamble(options?.context);
+    const glossaryBlock = buildGlossaryInstructions(
+        options?.glossary,
+        outputLanguageCode,
+    );
+
     const placeholderLine = buildPlaceholderLine(prefix, suffix);
 
-    return `${contextPreamble}You are a professional translator.
+    return `${contextPreamble}${glossaryBlock}You are a professional translator.
 
 Check translations from ${inputLanguage} to ${outputLanguage}.
 

--- a/src/glossary.ts
+++ b/src/glossary.ts
@@ -1,0 +1,128 @@
+import fs from "fs";
+import type Glossary from "./interfaces/glossary";
+
+/**
+ * Load and validate a glossary JSON file. Unlike the cache, a malformed
+ * glossary is a user configuration error, so this throws with a clear
+ * message rather than silently ignoring it.
+ * @param filePath - path to the glossary JSON file
+ * @returns the parsed glossary
+ */
+export function loadGlossary(filePath: string): Glossary {
+    let raw: string;
+    try {
+        raw = fs.readFileSync(filePath, "utf-8");
+    } catch (e) {
+        throw new Error(`Could not read glossary file ${filePath}: ${e}`);
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch (e) {
+        throw new Error(`Glossary ${filePath} is not valid JSON: ${e}`);
+    }
+
+    if (typeof parsed !== "object" || parsed === null) {
+        throw new Error(`Glossary ${filePath} must be a JSON object`);
+    }
+
+    const obj = parsed as Record<string, unknown>;
+
+    if (obj.doNotTranslate !== undefined) {
+        if (
+            !Array.isArray(obj.doNotTranslate) ||
+            !obj.doNotTranslate.every((t) => typeof t === "string")
+        ) {
+            throw new Error(
+                `Glossary ${filePath}: "doNotTranslate" must be an array of strings`,
+            );
+        }
+    }
+
+    if (obj.terms !== undefined) {
+        if (typeof obj.terms !== "object" || obj.terms === null) {
+            throw new Error(
+                `Glossary ${filePath}: "terms" must be an object keyed by language code`,
+            );
+        }
+
+        for (const [lang, mapping] of Object.entries(obj.terms)) {
+            if (
+                typeof mapping !== "object" ||
+                mapping === null ||
+                !Object.values(mapping).every((v) => typeof v === "string")
+            ) {
+                throw new Error(
+                    `Glossary ${filePath}: "terms.${lang}" must map source strings to translated strings`,
+                );
+            }
+        }
+    }
+
+    return obj as Glossary;
+}
+
+/**
+ * Resolve the forced-term map for a target language, accepting an exact
+ * match (e.g. `pt-BR`) or its base subtag (`pt`).
+ * @param glossary - the glossary
+ * @param outputLanguageCode - the run's target language code
+ * @returns the term map for that language, or undefined
+ */
+function termsForLanguage(
+    glossary: Glossary,
+    outputLanguageCode: string,
+): { [source: string]: string } | undefined {
+    if (!glossary.terms) return undefined;
+    if (glossary.terms[outputLanguageCode]) {
+        return glossary.terms[outputLanguageCode];
+    }
+
+    const base = outputLanguageCode.split(/[-_]/)[0];
+    return glossary.terms[base];
+}
+
+/**
+ * Build the glossary instruction block injected into a prompt for one
+ * target language. Returns an empty string when nothing applies, so
+ * callers can prepend it unconditionally.
+ * @param glossary - the glossary, or undefined
+ * @param outputLanguageCode - the run's target language code
+ * @returns the instruction block (ending in a blank line), or ""
+ */
+export function buildGlossaryInstructions(
+    glossary: Glossary | undefined,
+    outputLanguageCode: string,
+): string {
+    if (!glossary) return "";
+
+    const lines: string[] = [];
+
+    const dnt = (glossary.doNotTranslate ?? []).filter(
+        (t) => t.trim() !== "",
+    );
+    if (dnt.length > 0) {
+        const quoted = dnt.map((t) => `"${t}"`).join(", ");
+        lines.push(
+            `- Keep these terms exactly as written, do not translate them: ${quoted}.`,
+        );
+    }
+
+    const terms = termsForLanguage(glossary, outputLanguageCode);
+    if (terms) {
+        const pairs = Object.entries(terms)
+            .filter(([source]) => source.trim() !== "")
+            .map(([source, target]) => `"${source}" → "${target}"`);
+
+        if (pairs.length > 0) {
+            lines.push(
+                `- Use these exact translations for the following terms: ${pairs.join("; ")}.`,
+            );
+        }
+    }
+
+    if (lines.length === 0) return "";
+
+    return `Glossary (follow strictly):\n${lines.join("\n")}\n\n`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,22 +2,26 @@
 /* eslint-disable import/no-import-module-exports */
 import { check } from "./check";
 import { createCache, loadCache, saveCache } from "./cache";
+import { loadGlossary } from "./glossary";
 import { translate, translateDiff } from "./translate";
 
 export {
     check,
     createCache,
     loadCache,
+    loadGlossary,
     saveCache,
     translate,
     translateDiff,
 };
 export type { TranslationCache } from "./cache";
+export type { default as Glossary } from "./interfaces/glossary";
 
 module.exports = {
     check,
     createCache,
     loadCache,
+    loadGlossary,
     saveCache,
     translate,
     translateDiff,

--- a/src/interfaces/generate_translation_options_csv.ts
+++ b/src/interfaces/generate_translation_options_csv.ts
@@ -1,4 +1,5 @@
 import type Chats from "./chats";
+import type Glossary from "./glossary";
 import type OverridePrompt from "./override_prompt";
 import type RateLimiter from "../rate_limiter";
 
@@ -17,4 +18,5 @@ export default interface GenerateTranslationOptionsCSV {
     overridePrompt?: OverridePrompt;
     rateLimiter?: RateLimiter;
     context?: string;
+    glossary?: Glossary;
 }

--- a/src/interfaces/generate_translation_options_json.ts
+++ b/src/interfaces/generate_translation_options_json.ts
@@ -1,5 +1,6 @@
 import type { TranslateItem } from "../generate_json/types";
 import type Chats from "./chats";
+import type Glossary from "./glossary";
 import type OverridePrompt from "./override_prompt";
 import type RateLimiter from "../rate_limiter";
 
@@ -17,4 +18,5 @@ export default interface GenerateTranslationOptionsJSON {
     overridePrompt?: OverridePrompt;
     rateLimiter?: RateLimiter;
     context?: string;
+    glossary?: Glossary;
 }

--- a/src/interfaces/glossary.ts
+++ b/src/interfaces/glossary.ts
@@ -1,0 +1,18 @@
+/**
+ * A glossary steers terminology during translation. Both fields are
+ * optional and are injected into the model prompts (generation and
+ * verification) — enforcement is prompt-based, like `--context`.
+ */
+export default interface Glossary {
+    /**
+     * Terms that must be kept verbatim in every target language — brand
+     * names, product names, trademarks, code identifiers, etc.
+     */
+    doNotTranslate?: string[];
+    /**
+     * Forced translations, keyed by target language code, then by source
+     * term. e.g. `{ fr: { Account: "Compte" }, es: { Account: "Cuenta" } }`.
+     * Only the entry matching the run's output language is applied.
+     */
+    terms?: { [languageCode: string]: { [source: string]: string } };
+}

--- a/src/interfaces/options.ts
+++ b/src/interfaces/options.ts
@@ -2,6 +2,7 @@ import type { ChatParams, Model } from "../types";
 import type { TranslationCache } from "../cache";
 import type ChatPool from "../chat_pool";
 import type Engine from "../enums/engine";
+import type Glossary from "./glossary";
 import type OverridePrompt from "./override_prompt";
 import type PromptMode from "../enums/prompt_mode";
 import type RateLimiter from "../rate_limiter";
@@ -61,4 +62,11 @@ export default interface Options {
      * this up behind `--cache`; library callers may pass their own.
      */
     cache?: TranslationCache;
+    /**
+     * Optional glossary steering terminology: terms to keep verbatim
+     * (brand/product names) and forced per-language translations. Injected
+     * into the generation and verification prompts. The CLI wires this up
+     * behind `--glossary`; library callers may pass their own.
+     */
+    glossary?: Glossary;
 }

--- a/src/test/glossary.spec.ts
+++ b/src/test/glossary.spec.ts
@@ -1,0 +1,117 @@
+import { buildGlossaryInstructions, loadGlossary } from "../glossary";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import type Glossary from "../interfaces/glossary";
+
+const writeGlossary = (content: string): string => {
+    const file = path.join(
+        fs.mkdtempSync(path.join(os.tmpdir(), "i18n-glossary-")),
+        "glossary.json",
+    );
+
+    fs.writeFileSync(file, content);
+    return file;
+};
+
+describe("loadGlossary", () => {
+    it("loads a valid glossary", () => {
+        const file = writeGlossary(
+            JSON.stringify({
+                doNotTranslate: ["Acme"],
+                terms: { fr: { Account: "Compte" } },
+            }),
+        );
+
+        const glossary = loadGlossary(file);
+        expect(glossary.doNotTranslate).toEqual(["Acme"]);
+        expect(glossary.terms?.fr?.Account).toBe("Compte");
+    });
+
+    it("accepts an empty object", () => {
+        expect(loadGlossary(writeGlossary("{}"))).toEqual({});
+    });
+
+    it("throws for a missing file", () => {
+        expect(() => loadGlossary("/no/such/glossary.json")).toThrow(
+            /Could not read glossary/,
+        );
+    });
+
+    it("throws for invalid JSON", () => {
+        expect(() => loadGlossary(writeGlossary("{ not json"))).toThrow(
+            /not valid JSON/,
+        );
+    });
+
+    it("throws when doNotTranslate is not a string array", () => {
+        const file = writeGlossary(JSON.stringify({ doNotTranslate: [1, 2] }));
+        expect(() => loadGlossary(file)).toThrow(/doNotTranslate/);
+    });
+
+    it("throws when terms is not a nested string map", () => {
+        const file = writeGlossary(
+            JSON.stringify({ terms: { fr: { Account: 5 } } }),
+        );
+
+        expect(() => loadGlossary(file)).toThrow(/terms\.fr/);
+    });
+
+    it("throws when the root is not an object", () => {
+        expect(() => loadGlossary(writeGlossary("42"))).toThrow(
+            /must be a JSON object/,
+        );
+    });
+
+    it("throws when terms is not an object", () => {
+        const file = writeGlossary(JSON.stringify({ terms: "nope" }));
+        expect(() => loadGlossary(file)).toThrow(/keyed by language code/);
+    });
+});
+
+describe("buildGlossaryInstructions", () => {
+    const glossary: Glossary = {
+        doNotTranslate: ["Acme", "ProductX"],
+        terms: {
+            es: { Account: "Cuenta" },
+            fr: { Account: "Compte", Settings: "Paramètres" },
+            pt: { Account: "Conta" },
+        },
+    };
+
+    it("returns empty string when there is no glossary", () => {
+        expect(buildGlossaryInstructions(undefined, "fr")).toBe("");
+    });
+
+    it("returns empty string when nothing applies to the language", () => {
+        expect(buildGlossaryInstructions({ terms: { fr: {} } }, "de")).toBe("");
+    });
+
+    it("lists do-not-translate terms", () => {
+        const out = buildGlossaryInstructions(
+            { doNotTranslate: ["Acme"] },
+            "fr",
+        );
+
+        expect(out).toContain("do not translate them");
+        expect(out).toContain("\"Acme\"");
+    });
+
+    it("includes only the matching language's forced terms", () => {
+        const out = buildGlossaryInstructions(glossary, "fr");
+        expect(out).toContain("\"Account\" → \"Compte\"");
+        expect(out).toContain("\"Settings\" → \"Paramètres\"");
+        // The Spanish term must not leak into the French prompt.
+        expect(out).not.toContain("Cuenta");
+    });
+
+    it("falls back to the base subtag for BCP-47 codes", () => {
+        const out = buildGlossaryInstructions(glossary, "pt-BR");
+        expect(out).toContain("\"Account\" → \"Conta\"");
+    });
+
+    it("ends in a blank line so it can be prepended to a prompt", () => {
+        const out = buildGlossaryInstructions({ doNotTranslate: ["Acme"] }, "fr");
+        expect(out.endsWith("\n\n")).toBe(true);
+    });
+});

--- a/src/test/prompts.spec.ts
+++ b/src/test/prompts.spec.ts
@@ -52,6 +52,38 @@ describe("prompt builders", () => {
         });
     });
 
+    describe("glossary injection", () => {
+        const glossary = {
+            doNotTranslate: ["Acme"],
+            terms: { es: { Account: "Cuenta" }, fr: { Account: "Compte" } },
+        };
+
+        it("injects do-not-translate and the matching language's terms (JSON generation)", () => {
+            const out = translationPromptJSON("en", "fr", [], { glossary });
+            expect(out).toContain("Glossary (follow strictly):");
+            expect(out).toContain("\"Acme\"");
+            expect(out).toContain("\"Account\" → \"Compte\"");
+            // The Spanish forced term must not leak into a French prompt.
+            expect(out).not.toContain("Cuenta");
+        });
+
+        it("injects the glossary into the JSON verification prompt", () => {
+            const out = verificationPromptJSON("en", "fr", [], { glossary });
+            expect(out).toContain("\"Account\" → \"Compte\"");
+        });
+
+        it("injects the glossary into CSV generation", () => {
+            const out = csvGenerationPrompt("en", "fr", '"hello"', { glossary });
+            expect(out).toContain("Glossary (follow strictly):");
+            expect(out).toContain("\"Account\" → \"Compte\"");
+        });
+
+        it("omits the glossary block when none is provided", () => {
+            const out = translationPromptJSON("en", "fr", []);
+            expect(out).not.toContain("Glossary (follow strictly):");
+        });
+    });
+
     describe("plural-suffix hints", () => {
         it("fires when any key ends in a CLDR plural suffix", () => {
             const out = translationPromptJSON("en", "fr", [], {


### PR DESCRIPTION
## Summary

Adds a **glossary** for terminology control — the next adoption lever for quality-conscious teams (brand names, fixed vocabulary). Opt-in via `--glossary <path>` on `translate` and `diff`, pointing to a JSON file:

```json
{
  "doNotTranslate": ["Acme", "ProductX"],
  "terms": { "fr": { "Account": "Compte" }, "es": { "Account": "Cuenta" } }
}
```

- **`doNotTranslate`** keeps brand/product names verbatim in every language.
- **`terms`** forces exact per-language translations.

Both sections compile into an instruction block injected right after the existing context preamble in **all four prompts** (JSON + CSV, generation + verification), so the verifier won't "correct" a forced term and the generator honors do-not-translate. Only the run's target language is applied, with a BCP-47 base-subtag fallback (`pt` covers `pt-BR`). Enforcement is prompt-based, like `--context`.

## What changed

- **`src/glossary.ts`** — `loadGlossary` (validates and **throws on malformed config** — unlike the cache, a bad glossary is a user error worth surfacing, not silently ignoring) and `buildGlossaryInstructions` (language-scoped, returns `""` when nothing applies so callers prepend unconditionally).
- Threaded through `Options` and both generate-options interfaces; passed at every prompt call site; exposed as `${glossary}` to override-prompt files.
- **CLI** `--glossary <path>` on `translate` + `diff`.
- **`index.ts`** exports `loadGlossary` + the `Glossary` type for library callers.
- README documents the flag and the language-scoping behavior.

## Tests

`glossary.spec.ts` (load/validate incl. malformed/missing-field throws; instruction building; language scoping; base-subtag fallback) and `prompts.spec.ts` injection tests across JSON + CSV. Full suite **224 passed**, 0 lint errors, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
