### PR TITLE
Fix Bug 6: tolerate blank lines in CSV model responses

### DIFF
--- a/src/generate_csv/generate.ts
+++ b/src/generate_csv/generate.ts
@@ -180,6 +180,21 @@ async function runShard(
     }
 }
 
+/**
+ * Split a model's CSV translation response into one entry per line,
+ * dropping blank lines. The model often pads the response with a
+ * trailing newline or blank separator lines; a genuine CSV translation
+ * is always a quoted string, so an empty line is never valid output —
+ * only noise. Filtering it here keeps the downstream line-count check
+ * from rejecting (and ultimately dropping) the whole batch over a stray
+ * blank line. See Bug 6.
+ * @param text - the raw model response
+ * @returns the non-empty lines
+ */
+export function splitTranslationLines(text: string): string[] {
+    return text.split("\n").filter((line) => line.trim() !== "");
+}
+
 async function generate(
     options: GenerateTranslationOptionsCSV,
     generationPromptText: string,
@@ -233,12 +248,17 @@ async function generate(
         text = text.slice(4, -4);
     }
 
-    // Response length matches
-    const splitText = text.split("\n");
+    // Response length matches. Blank lines (a trailing newline, stray
+    // separators) are dropped first so they don't trip the strict
+    // count check and cause an otherwise-valid batch to be retried into
+    // oblivion and silently skipped. See Bug 6.
+    const splitText = splitTranslationLines(text);
     if (splitText.length !== keys.length) {
         chats.generateTranslationChat.rollbackLastMessage();
         return Promise.reject(
-            new Error(`Invalid number of lines. text = ${text}`),
+            new Error(
+                `Invalid number of lines: expected ${keys.length}, got ${splitText.length}. text = ${text}`,
+            ),
         );
     }
 

--- a/src/test/concurrency.spec.ts
+++ b/src/test/concurrency.spec.ts
@@ -25,6 +25,9 @@ const chatCalls: ChatCall[] = [];
 let nextChatId = 1;
 let failKeys: Set<string> | null = null;
 let rejectOn429Once: Set<string> | null = null;
+// When true, the fake appends blank lines to the CSV response to
+// simulate a model padding its output with a trailing newline (Bug 6).
+let csvTrailingBlank = false;
 
 function mintChatId(): number {
     const id = nextChatId;
@@ -115,7 +118,11 @@ function makeFakeChat(): {
                     throw err;
                 }
 
-                return inputs.map((s) => `"${fakeTranslate(s)}"`).join("\n");
+                const body = inputs
+                    .map((s) => `"${fakeTranslate(s)}"`)
+                    .join("\n");
+
+                return csvTrailingBlank ? `${body}\n\n` : body;
             }
 
             if (fmt === "json-translate") {
@@ -241,6 +248,7 @@ beforeEach(() => {
     nextChatId = 1;
     failKeys = null;
     rejectOn429Once = null;
+    csvTrailingBlank = false;
 });
 
 const toyInput = (): Record<string, string> => ({
@@ -406,6 +414,27 @@ describe("CSV styling verification", () => {
         );
 
         expect(stylingCalls).toHaveLength(0);
+    });
+});
+
+describe("CSV blank-line tolerance (Bug 6)", () => {
+    it("still translates every key when the model pads the response with blank lines", async () => {
+        // Before the fix, a trailing blank line made the response line
+        // count exceed keys.length; the batch was rejected on every
+        // retry and the keys were silently dropped from the output.
+        csvTrailingBlank = true;
+
+        const result = (await translate({
+            ...baseOptions,
+            concurrency: 1,
+            inputJSON: { greeting: "Hello", parting: "Bye" },
+            promptMode: PromptMode.CSV,
+        } as any)) as Record<string, string>;
+
+        expect(result).toEqual({
+            greeting: fakeTranslate("Hello"),
+            parting: fakeTranslate("Bye"),
+        });
     });
 });
 

--- a/src/test/generate_csv.spec.ts
+++ b/src/test/generate_csv.spec.ts
@@ -1,0 +1,23 @@
+import { splitTranslationLines } from "../generate_csv/generate";
+
+describe("splitTranslationLines (Bug 6)", () => {
+    it("returns each line for a clean response", () => {
+        expect(splitTranslationLines('"a"\n"b"\n"c"')).toEqual([
+            '"a"',
+            '"b"',
+            '"c"',
+        ]);
+    });
+
+    it("drops a trailing newline the model often appends", () => {
+        expect(splitTranslationLines('"a"\n"b"\n')).toEqual(['"a"', '"b"']);
+    });
+
+    it("drops blank separator and leading blank lines", () => {
+        expect(splitTranslationLines('\n"a"\n\n"b"\n')).toEqual(['"a"', '"b"']);
+    });
+
+    it("treats whitespace-only lines as blank", () => {
+        expect(splitTranslationLines('"a"\n   \n"b"')).toEqual(['"a"', '"b"']);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes **Bug 6** from the integration report: in CSV prompt mode, certain `(key, locale)` pairs failed on every retry and were **silently dropped** from the output (the run still exits 0 under `--continue-on-error`, so the gap only surfaced via a downstream linter).

## Root cause

`generate_csv/generate.ts` rejected a whole batch whenever the model's response line count didn't *exactly* equal `keys.length`:

```ts
const splitText = text.split("\n");
if (splitText.length !== keys.length) { /* reject → retry identically */ }
```

The model frequently pads its output with a trailing newline or blank separator lines, so the strict check failed — and since the retry re-prompts the same way, the mismatch was deterministic for some inputs, which then got skipped.

## Fix

A genuine CSV translation line is always a quoted string, and the downstream per-line check already rejects any unquoted line — so a blank line is never valid output, only noise. Drop blank lines before the count check:

```ts
export function splitTranslationLines(text: string): string[] {
    return text.split("\n").filter((line) => line.trim() !== "");
}
```

Extracted as a named helper for a clear unit test. The count-mismatch error now also reports `expected N, got M` instead of just echoing the (already-stripped) response — the report noted the old message was misleading.

This is the deterministic half of the bug (stray blank lines). The non-deterministic mid-string-wrap case would want a per-key (batch-size-1) fallback; left as a follow-up.

## Tests

- `generate_csv.spec.ts` — `splitTranslationLines` unit cases (trailing newline, blank separators, leading blank, whitespace-only).
- `concurrency.spec.ts` — end-to-end case asserting every key still translates when the model pads the CSV response with blank lines (fails before this change).

Full suite **211 passed**, 0 lint errors, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
