### PR TITLE
feat(formats): add a Rails YAML adapter

### DIFF
--- a/ADVANCED_GUIDE.md
+++ b/ADVANCED_GUIDE.md
@@ -34,8 +34,11 @@ Every format goes through the same pipeline: an adapter parses the file into the
 | `po` | `.po` | Comments, `msgctxt`, plural forms, headers | `%s`, `%d`, `%1$s` |
 | `properties` | `.properties` | Comments, separators, line continuations, escapes | `{0}`, `{1,date,short}` |
 | `strings` | `.strings` | `/* */` and `//` comments, quoting, escapes | `%@`, `%1$@`, `%d` |
+| `yaml` | `.yml`, `.yaml` | Comments, key order, quoting/block style | `%{name}`, `%<name>s` |
 
 The format is inferred from the file extension; pass `--file-format` to override. All formats work across `translate` (file and directory), `diff`, and `check`.
+
+**Rails YAML.** A locale-rooted file (`en:` as the single top-level key) has that root held out of the translation keys and retargeted to the output language on write, so `en.yml` → `fr.yml` comes back rooted at `fr:`. Files without a locale root are treated as a plain catalogue. Non-string scalars (numbers, booleans, dates) are left alone.
 
 https://github.com/user-attachments/assets/4909bf01-3e7a-464a-9c6e-2d1b82cc47d0
 
@@ -160,7 +163,7 @@ Options:
   --exclude-languages [language codes...]     Language codes to skip
   --tokens-per-minute <tpm>                   Cap tokens-per-minute across all concurrent workers (disabled by default)
   --language-concurrency <n>                  How many target languages to translate in parallel (default: 1)
-  --file-format <format>                      json, po, properties, strings (default: inferred from extension)
+  --file-format <format>                      json, po, properties, strings, yaml (default: inferred from extension)
   --cache [path]                              Reuse a translation memory across runs (default: .i18n-ai-translate-cache.json)
   --glossary <path>                           Path to a glossary JSON file steering terminology
   --help                                      display help for command
@@ -224,7 +227,7 @@ Options:
   --context <context>                       Domain context
   --exclude-languages [language codes...]   Locales to skip
   --tokens-per-minute <tpm>                 TPM cap
-  --file-format <format>                    json, po, properties, strings (default: from extension)
+  --file-format <format>                    json, po, properties, strings, yaml (default: from extension)
   --cache [path]                            Reuse a translation memory across runs
   --glossary <path>                         Glossary JSON file steering terminology
   --help                                    display help for command
@@ -270,7 +273,7 @@ Options:
   --context <context>                         Domain context
   --tokens-per-minute <tpm>                   TPM cap
   --format <format>                           'table' (default) or 'json'
-  --file-format <format>                      json, po, properties, strings (default: from extension)
+  --file-format <format>                      json, po, properties, strings, yaml (default: from extension)
   --help                                      display help for command
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build](https://img.shields.io/github/actions/workflow/status/taahamahdi/i18n-ai-translate/build.yml?branch=master)](https://github.com/taahamahdi/i18n-ai-translate/actions/workflows/build.yml)
 [![License: GPL‑3.0](https://img.shields.io/npm/l/i18n-ai-translate.svg)](https://github.com/taahamahdi/i18n-ai-translate/blob/master/LICENSE)
 
-AI‑powered localization for your translation catalogues. Automate translating single files or entire directories with ChatGPT, Gemini, Claude, or local Ollama models — while keeping translations accurate, formatting consistent, and placeholders intact. Works with **i18next‑style** JSON out of the box, plus Gettext `.po`, Java `.properties`, and iOS `.strings`.
+AI‑powered localization for your translation catalogues. Automate translating single files or entire directories with ChatGPT, Gemini, Claude, or local Ollama models — while keeping translations accurate, formatting consistent, and placeholders intact. Works with **i18next‑style** JSON out of the box, plus Gettext `.po`, Java `.properties`, iOS `.strings`, and Rails YAML.
 
 _For a detailed walkthrough and advanced tips, see [ADVANCED_GUIDE.md](ADVANCED_GUIDE.md)._
 
@@ -20,7 +20,7 @@ _For a detailed walkthrough and advanced tips, see [ADVANCED_GUIDE.md](ADVANCED_
 | **Safe**              | Translations verified against the source before being written                           |
 | **Diff‑aware**        | Only re‑translate keys you changed; existing translations are preserved                 |
 | **Check mode**        | Audit existing translations for drift, missing placeholders, or quality regressions     |
-| **Format‑aware**      | i18next JSON, Gettext `.po`, Java `.properties`, iOS `.strings` — round‑tripped intact  |
+| **Format‑aware**      | i18next JSON, Gettext `.po`, Java `.properties`, iOS `.strings`, Rails `.yml` — round‑tripped intact |
 | **Context-aware**     | `--context` flag injects product info so the model picks domain-appropriate terminology |
 | **Dry‑run**           | Preview updates before touching disk                                                    |
 | **Everywhere**        | Use as a CLI, GitHub Action, or Node library                                            |
@@ -45,7 +45,17 @@ i18n-ai-translate translate -i i18n/en.json -o fr \
 
 Need more languages? Pass multiple codes (`-o fr es de`) or `-A` for **all** 180+. Filenames like `es-ES.json` / `pt-BR.json` are accepted too — the language subtag is extracted automatically. Skip specific locales with `--exclude-languages fr de` (handy for locales you maintain by hand).
 
-**Other formats:** besides i18next JSON, Gettext `.po`, Java `.properties`, and iOS `.strings` files work too — the format is inferred from the file extension (override with `--file-format json|po|properties|strings`). Non-translatable structure round-trips losslessly: PO comments, `msgctxt`, and plural forms; `.properties` comments, separators, and line continuations; `.strings` `/* */` and `//` comments and quoting. Native placeholders (`printf` `%s`/`%1$s`/`%@`, MessageFormat `{0}`/`{1}`) are preserved across the translation. Works across `translate` (file + folder), `diff`, and `check`.
+**Other formats:** besides i18next JSON, Gettext `.po`, Java `.properties`, iOS `.strings`, and Rails `.yml`/`.yaml` files work too — the format is inferred from the file extension (override with `--file-format json|po|properties|strings|yaml`). Non-translatable structure round-trips losslessly: PO comments, `msgctxt`, and plural forms; `.properties` comments, separators, and line continuations; `.strings` `/* */` and `//` comments and quoting; YAML comments, key order, and quoting style. Native placeholders (`printf` `%s`/`%1$s`/`%@`, MessageFormat `{0}`/`{1}`, Rails `%{name}`/`%<name>s`) are preserved across the translation. Works across `translate` (file + folder), `diff`, and `check`.
+
+Rails YAML files may be locale-rooted (`en:` at the top level); the root key is retargeted to the output language on write, so `en.yml` → `fr.yml` gets `fr:`.
+
+```yaml
+# en.yml                          # fr.yml, after `translate -i en.yml -o fr`
+en:                               fr:
+  greeting: Hello                   greeting: Bonjour
+  inbox:                            inbox:
+    unread: "%{count} unread"         unread: "%{count} non lus"
+```
 
 ### 3 · Translate a folder
 
@@ -113,7 +123,7 @@ Common flags (all subcommands accept these unless noted):
 | `--no-continue-on-error`  | continue        | Abort on first key/batch failure instead of skipping                            |
 | `--dry-run`               | false           | Don't write files, preview instead (translate/diff only)                        |
 | `--cache [path]`          | off             | Reuse a translation memory across runs; skip unchanged strings (translate/diff) |
-| `--file-format`           | from extension  | File format: `json`, `po`, `properties`, `strings` (translate/diff/check)       |
+| `--file-format`           | from extension  | File format: `json`, `po`, `properties`, `strings`, `yaml` (translate/diff/check) |
 | `--format`                | table           | `table` or `json` report output (check only)                                    |
 
 Full flag list: `i18n-ai-translate <subcommand> --help`.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ollama": "^0.5.12",
     "openai": "^5.6.0",
     "typescript": "^5.1.6",
+    "yaml": "^2.9.0",
     "zod": "^3.24.2",
     "zod-to-json-schema": "^3.24.1"
   },
@@ -81,12 +82,13 @@
     "llama",
     "gettext",
     "po",
+    "yaml",
     "cli",
     "github-action"
   ],
   "author": "Taaha Mahdi",
   "license": "GPL-3.0",
-  "description": "AI-powered localization CLI, Node library, and GitHub Action. Translate i18next JSON, Gettext PO, Java .properties, and iOS .strings with ChatGPT, Claude, Gemini, or local Ollama models.",
+  "description": "AI-powered localization CLI, Node library, and GitHub Action. Translate i18next JSON, Gettext PO, Java .properties, iOS .strings, and Rails YAML with ChatGPT, Claude, Gemini, or local Ollama models.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/taahamahdi/i18n-ai-translate.git"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,7 +36,7 @@ export const CLI_HELP = {
     ExcludeLanguages:
         "Language codes to skip (e.g. 'fr de'). Useful when some locales are maintained manually and shouldn't be machine-translated over",
     FileFormat:
-        "Input/output file format (default: inferred from extension). Supported: json, po, properties, strings.",
+        "Input/output file format (default: inferred from extension). Supported: json, po, properties, strings, yaml.",
     Glossary:
         "Path to a glossary JSON file steering terminology: { \"doNotTranslate\": [\"Acme\"], \"terms\": { \"fr\": { \"Account\": \"Compte\" } } }. Injected into the generation and verification prompts",
     LanguageConcurrency:

--- a/src/formats/registry.ts
+++ b/src/formats/registry.ts
@@ -2,6 +2,7 @@ import JSONAdapter from "./json_adapter";
 import POAdapter from "./po_adapter";
 import PropertiesAdapter from "./properties_adapter";
 import StringsAdapter from "./strings_adapter";
+import YAMLAdapter from "./yaml_adapter";
 import path from "path";
 import type FormatAdapter from "./format_adapter";
 
@@ -13,6 +14,7 @@ const ADAPTERS: readonly FormatAdapter<unknown>[] = [
     POAdapter,
     PropertiesAdapter,
     StringsAdapter,
+    YAMLAdapter,
 ];
 
 /**

--- a/src/formats/yaml_adapter.ts
+++ b/src/formats/yaml_adapter.ts
@@ -1,0 +1,244 @@
+import { FLATTEN_DELIMITER } from "../constants";
+import { isMap, isScalar, isSeq, parseDocument } from "yaml";
+import { isValidLanguageCode } from "../utils";
+import type { Node, Scalar } from "yaml";
+import type FormatAdapter from "./format_adapter";
+
+/**
+ * Rails I18n interpolation: `%{count}`, and the sprintf-style
+ * `%<count>d` / `%<price>.2f` variant. Capture groups: (1) the name in
+ * `%{name}` form, (2) the name in `%<name>` form.
+ *
+ * Deliberately tolerant — the adapter's contract is "whatever we strip
+ * on read, we restore on write", so an unrecognised token is simply
+ * left alone in both directions.
+ */
+const RAILS_INTERPOLATION_REGEX =
+    /%\{([^}]+)\}|%<([^>]+)>[-+ #0]*\d*(?:\.\d+)?[sdifFeEgGxXoub]/g;
+
+/** Native interpolation tokens, keyed by the variable name they carry. */
+type PlaceholderMap = Record<string, string>;
+
+type YAMLEntry = {
+    /** Path to the scalar *within the catalogue*, i.e. below the locale root. */
+    path: (string | number)[];
+    /** Placeholder-stripped original value; "unchanged" sentinel on write. */
+    original: string;
+    placeholders: PlaceholderMap;
+};
+
+/**
+ * The original source text plus the map from flat key back to its
+ * position in the document.
+ *
+ * Unlike the other adapters we keep the raw text rather than the parsed
+ * tree: `write` re-parses it every call so comments, anchors, quoting
+ * styles, and key order survive, and so that one sidecar can be written
+ * out once per target language without earlier languages leaking into
+ * later ones (`translateDiff` reuses a single source sidecar).
+ */
+type YAMLSidecar = {
+    kind: "yaml";
+    raw: string;
+    /**
+     * The single top-level locale key (`en:`) when the file is a Rails-style
+     * locale-rooted catalogue, or null for a plain unrooted mapping. Held
+     * out of the flat keys so a source `en:` and a target `fr:` produce
+     * identical keys and diff mode can line them up.
+     */
+    localeRoot: string | null;
+    entries: Record<string, YAMLEntry>;
+};
+
+/**
+ * Whether a top-level key looks like the locale wrapper Rails uses.
+ * Accepts BCP-47 forms (`pt-BR`) by checking the subtag prefix, mirroring
+ * `getLanguageCodeFromFilename`.
+ * @param key - the candidate top-level key
+ * @returns whether it should be treated as the locale root
+ */
+function looksLikeLocaleRoot(key: string): boolean {
+    if (isValidLanguageCode(key)) return true;
+    const [prefix] = key.split("-");
+    return isValidLanguageCode(prefix);
+}
+
+function stripPlaceholders(text: string): {
+    normalized: string;
+    map: PlaceholderMap;
+} {
+    const map: PlaceholderMap = {};
+    const normalized = text.replace(
+        RAILS_INTERPOLATION_REGEX,
+        (match, braceName, angleName) => {
+            const name = braceName ?? angleName;
+            map[name] = match;
+            return `{{${name}}}`;
+        },
+    );
+
+    return { map, normalized };
+}
+
+function restorePlaceholders(text: string, map: PlaceholderMap): string {
+    if (Object.keys(map).length === 0) return text;
+    return text.replace(/\{\{([^{}]+)\}\}/g, (match, name) => {
+        // A `{{var}}` the source didn't have (already-`{{}}` content, or a
+        // model invention) is left literal rather than silently dropped —
+        // same stance as the PO and .properties adapters.
+        const original = map[name];
+        return original ?? match;
+    });
+}
+
+/**
+ * Rebuild a document path from a flat key for entries the source
+ * catalogue didn't contain. All-digit segments become array indices,
+ * matching how `collect` records sequence positions.
+ * @param flatKey - the pipeline's flat key
+ * @returns the path segments
+ */
+function splitFlatKey(flatKey: string): (string | number)[] {
+    return flatKey
+        .split(FLATTEN_DELIMITER)
+        .map((segment) => (/^\d+$/.test(segment) ? Number(segment) : segment));
+}
+
+/**
+ * Recursively collect every string scalar under `node`, recording its
+ * flat key and its path within the catalogue. Non-string scalars
+ * (numbers, booleans, dates, null) are not translatable and are left
+ * untouched in the document.
+ * @param node - the current node
+ * @param currentPath - path accumulated so far
+ * @param flat - flat map being built
+ * @param entries - sidecar entries being built
+ */
+function collect(
+    node: unknown,
+    currentPath: (string | number)[],
+    flat: Record<string, string>,
+    entries: Record<string, YAMLEntry>,
+): void {
+    if (isMap(node)) {
+        for (const item of node.items) {
+            const key = isScalar(item.key) ? item.key.value : item.key;
+            if (typeof key !== "string" && typeof key !== "number") continue;
+            collect(item.value, [...currentPath, key], flat, entries);
+        }
+
+        return;
+    }
+
+    if (isSeq(node)) {
+        for (let i = 0; i < node.items.length; i++) {
+            collect(node.items[i], [...currentPath, i], flat, entries);
+        }
+
+        return;
+    }
+
+    if (!isScalar(node) || typeof node.value !== "string") return;
+
+    const flatKey = currentPath.join(FLATTEN_DELIMITER);
+    const { normalized, map } = stripPlaceholders(node.value);
+    flat[flatKey] = normalized;
+    entries[flatKey] = {
+        original: normalized,
+        path: currentPath,
+        placeholders: map,
+    };
+}
+
+const YAMLAdapter: FormatAdapter<YAMLSidecar> = {
+    extensions: [".yml", ".yaml"] as const,
+    name: "yaml",
+
+    read(raw: string): { flat: Record<string, string>; sidecar: YAMLSidecar } {
+        const doc = parseDocument(raw);
+        if (doc.errors.length > 0) {
+            throw new Error(doc.errors[0].message);
+        }
+
+        const contents = doc.contents as Node | null;
+
+        // A Rails locale file wraps everything in a single top-level
+        // language key. Strip it so the flat keys are language-neutral.
+        let localeRoot: string | null = null;
+        let catalogue: unknown = contents;
+        if (isMap(contents) && contents.items.length === 1) {
+            const only = contents.items[0];
+            const key = isScalar(only.key) ? only.key.value : undefined;
+            if (typeof key === "string" && looksLikeLocaleRoot(key)) {
+                localeRoot = key;
+                catalogue = only.value;
+            }
+        }
+
+        const flat: Record<string, string> = {};
+        const entries: Record<string, YAMLEntry> = {};
+        collect(catalogue, [], flat, entries);
+
+        return { flat, sidecar: { entries, kind: "yaml", localeRoot, raw } };
+    },
+
+    write(
+        translated: Record<string, string>,
+        sidecar: YAMLSidecar,
+        _inputLanguageCode: string,
+        outputLanguageCode: string,
+    ): string {
+        // Re-parse rather than mutate: the caller may hand the same
+        // sidecar to `write` once per target language.
+        const doc = parseDocument(sidecar.raw);
+
+        // Retarget the locale wrapper — a `fr.yml` whose root key is
+        // still `en:` is silently ignored by Rails I18n.
+        const contents = doc.contents as Node | null;
+        if (sidecar.localeRoot !== null && isMap(contents)) {
+            const rootKey = contents.items[0].key;
+            if (isScalar(rootKey)) {
+                (rootKey as Scalar).value = outputLanguageCode;
+            }
+        }
+
+        const prefix: (string | number)[] =
+            sidecar.localeRoot !== null ? [outputLanguageCode] : [];
+
+        for (const [flatKey, value] of Object.entries(translated)) {
+            const entry = sidecar.entries[flatKey];
+            // Unchanged (or skipped) values keep the source node exactly
+            // as written, preserving its quoting and any block style.
+            if (entry && value === entry.original) continue;
+
+            // A key the source catalogue never had comes from the existing
+            // target file (diff mode), so we have no captured token map for
+            // it. `%{name}` is the canonical Rails form, so that is the
+            // inverse we assume — versus a known entry, where an
+            // unrecognised `{{var}}` is left literal because we know it
+            // wasn't in the source.
+            const restored = entry
+                ? restorePlaceholders(value, entry.placeholders)
+                : value.replace(/\{\{([^{}]+)\}\}/g, "%{$1}");
+
+            const fullPath = [
+                ...prefix,
+                ...(entry ? entry.path : splitFlatKey(flatKey)),
+            ];
+
+            const existing = doc.getIn(fullPath, true);
+            if (isScalar(existing)) {
+                // Assigning through the existing node keeps its quoting
+                // style; the stringifier upgrades the style by itself if
+                // the new text can no longer be represented that way.
+                existing.value = restored;
+            } else {
+                doc.setIn(fullPath, restored);
+            }
+        }
+
+        return doc.toString();
+    },
+};
+
+export default YAMLAdapter;

--- a/src/test/formats.spec.ts
+++ b/src/test/formats.spec.ts
@@ -9,6 +9,7 @@ import JSONAdapter from "../formats/json_adapter";
 import POAdapter from "../formats/po_adapter";
 import PropertiesAdapter from "../formats/properties_adapter";
 import StringsAdapter from "../formats/strings_adapter";
+import YAMLAdapter from "../formats/yaml_adapter";
 
 // ASCII Record Separator — must match KEY_DELIMITER in po_adapter.ts.
 const SEP = "\x1e";
@@ -76,12 +77,20 @@ describe("format registry", () => {
         expect(getAdapterForFile("Localizable.strings")).toBe(StringsAdapter);
     });
 
+    it("resolves the YAML adapter by name and both extensions", () => {
+        expect(getAdapterByName("yaml")).toBe(YAMLAdapter);
+        expect(getAdapterByExtension(".yml")).toBe(YAMLAdapter);
+        expect(getAdapterByExtension(".yaml")).toBe(YAMLAdapter);
+        expect(getAdapterForFile("en.yml")).toBe(YAMLAdapter);
+    });
+
     it("lists registered format names", () => {
         expect(listFormatNames()).toEqual([
             "json",
             "po",
             "properties",
             "strings",
+            "yaml",
         ]);
     });
 });
@@ -699,5 +708,180 @@ describe("StringsAdapter", () => {
         const input = "/* c */\n\"k\" = \"v\";";
         const { flat, sidecar } = StringsAdapter.read(input);
         expect(StringsAdapter.write(flat, sidecar, "en", "en")).toBe(input);
+    });
+});
+
+const YAML_FIXTURE = [
+    "# Rails locale file",
+    "en:",
+    "  greeting: Hello",
+    "  inbox:",
+    "    # how many unread",
+    "    unread: \"You have %{count} messages\"",
+    "    price: '%<amount>.2f owing'",
+    "  day_names:",
+    "    - Monday",
+    "    - Tuesday",
+    "  retries: 3",
+    "",
+].join("\n");
+
+describe("YAMLAdapter", () => {
+    it("strips the locale root so source and target keys line up", () => {
+        const { flat } = YAMLAdapter.read(YAML_FIXTURE);
+
+        expect(flat).toEqual({
+            "day_names*0": "Monday",
+            "day_names*1": "Tuesday",
+            greeting: "Hello",
+            "inbox*price": "{{amount}} owing",
+            "inbox*unread": "You have {{count}} messages",
+        });
+
+        // The same catalogue under a different locale root reads
+        // identically — this is what makes diff mode line up.
+        const french = YAML_FIXTURE.replace("en:", "fr:");
+        expect(Object.keys(YAMLAdapter.read(french).flat).sort()).toEqual(
+            Object.keys(flat).sort(),
+        );
+    });
+
+    it("round-trips unchanged content, comments included", () => {
+        const { flat, sidecar } = YAMLAdapter.read(YAML_FIXTURE);
+        expect(YAMLAdapter.write(flat, sidecar, "en", "en")).toBe(YAML_FIXTURE);
+    });
+
+    it("retargets the locale root to the output language", () => {
+        const { flat, sidecar } = YAMLAdapter.read(YAML_FIXTURE);
+        const output = YAMLAdapter.write(
+            { ...flat, greeting: "Bonjour" },
+            sidecar,
+            "en",
+            "fr",
+        );
+
+        expect(output).toContain("fr:");
+        expect(output).not.toContain("en:");
+        expect(output).toContain("greeting: Bonjour");
+        expect(output).toContain("# Rails locale file");
+        expect(output).toContain("# how many unread");
+        // Untranslated scalars keep their original type and value.
+        expect(output).toContain("retries: 3");
+    });
+
+    it("restores Rails interpolation in both syntaxes", () => {
+        const { flat, sidecar } = YAMLAdapter.read(YAML_FIXTURE);
+        const output = YAMLAdapter.write(
+            {
+                ...flat,
+                "inbox*price": "{{amount}} dû",
+                "inbox*unread": "Vous avez {{count}} messages",
+            },
+            sidecar,
+            "en",
+            "fr",
+        );
+
+        expect(output).toContain("%{count} messages");
+        expect(output).toContain("%<amount>.2f dû");
+    });
+
+    it("leaves a model-invented placeholder literal on write", () => {
+        const { flat, sidecar } = YAMLAdapter.read(YAML_FIXTURE);
+        const output = YAMLAdapter.write(
+            { ...flat, "inbox*unread": "{{count}} et {{bogus}}" },
+            sidecar,
+            "en",
+            "fr",
+        );
+
+        expect(output).toContain("%{count} et {{bogus}}");
+    });
+
+    it("re-quotes a value whose original plain style can no longer hold it", () => {
+        const { flat, sidecar } = YAMLAdapter.read(YAML_FIXTURE);
+        const output = YAMLAdapter.write(
+            { ...flat, greeting: "Bonjour: le monde" },
+            sidecar,
+            "en",
+            "fr",
+        );
+
+        // Emitted plainly this would parse as a nested mapping.
+        expect(YAMLAdapter.read(output).flat.greeting).toBe(
+            "Bonjour: le monde",
+        );
+    });
+
+    it("does not mutate the sidecar between target languages", () => {
+        const { flat, sidecar } = YAMLAdapter.read(YAML_FIXTURE);
+        YAMLAdapter.write(
+            { ...flat, greeting: "Bonjour" },
+            sidecar,
+            "en",
+            "fr",
+        );
+        const second = YAMLAdapter.write(
+            { ...flat, greeting: "Hallo" },
+            sidecar,
+            "en",
+            "de",
+        );
+
+        expect(second).toContain("de:");
+        expect(second).toContain("greeting: Hallo");
+        expect(second).not.toContain("Bonjour");
+    });
+
+    it("treats a file with no locale root as a plain catalogue", () => {
+        const input = "greeting: Hello\nfarewell: Bye\n";
+        const { flat, sidecar } = YAMLAdapter.read(input);
+
+        expect(flat).toEqual({ farewell: "Bye", greeting: "Hello" });
+        expect(YAMLAdapter.write(flat, sidecar, "en", "fr")).toBe(input);
+    });
+
+    it("recognises a BCP-47 locale root", () => {
+        const { flat, sidecar } = YAMLAdapter.read("pt-BR:\n  greeting: Oi\n");
+        expect(flat).toEqual({ greeting: "Oi" });
+        expect(YAMLAdapter.write(flat, sidecar, "pt", "fr")).toBe(
+            "fr:\n  greeting: Oi\n",
+        );
+    });
+
+    it("does not treat a non-locale single root as a wrapper", () => {
+        const { flat } = YAMLAdapter.read("messages:\n  greeting: Hello\n");
+        expect(flat).toEqual({ "messages*greeting": "Hello" });
+    });
+
+    it("adds a key the source catalogue did not contain", () => {
+        const { flat, sidecar } = YAMLAdapter.read("en:\n  greeting: Hello\n");
+        const output = YAMLAdapter.write(
+            { ...flat, "inbox*unread": "Nouveau" },
+            sidecar,
+            "en",
+            "fr",
+        );
+
+        expect(YAMLAdapter.read(output).flat).toEqual({
+            greeting: "Hello",
+            "inbox*unread": "Nouveau",
+        });
+    });
+
+    it("assumes Rails %{} form for a key the source never had", () => {
+        const { flat, sidecar } = YAMLAdapter.read("en:\n  greeting: Hello\n");
+        const output = YAMLAdapter.write(
+            { ...flat, legacy: "{{count}} restants" },
+            sidecar,
+            "en",
+            "fr",
+        );
+
+        expect(output).toContain("%{count} restants");
+    });
+
+    it("throws on malformed YAML", () => {
+        expect(() => YAMLAdapter.read("en:\n  a: [1, 2\n")).toThrow();
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5264,6 +5264,11 @@ yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
+yaml@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
+  integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
+
 yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"


### PR DESCRIPTION
Adds `.yml`/`.yaml` support, completing Phase 2 of the format roadmap. Built on the `yaml` package so comments, key order, and quoting/block style round-trip; non-string scalars (numbers, booleans, dates) are left alone. Placeholders are Rails `%{name}` and `%<name>s`.

Two wrinkles worth review attention, since neither shows up in the existing adapters:

**The locale root has to be held out of the flat keys.** A Rails file is rooted at a single locale key (`en:`). If that key stays in the flat map, a source rooted at `en:` and a target rooted at `fr:` produce keys that never line up, and diff mode cant match them. Its stripped on read and *retargeted* to the output language on write — Rails ignores a `fr.yml` still rooted at `en:`. Files with no locale root are treated as a plain catalogue.

**The sidecar re-parses on write.** It keeps the raw source rather than a parsed document, because `translateDiff` reuses one sidecar across every target language and a shared mutable document would let one languages writes leak into the next. The PO adapter has the same hazard, handled there with a deep clone.

One bug caught while writing the tests: the write path originally iterated the source entries, which silently dropped keys present only in an existing target file — a real data-loss path in diff mode. It now walks the translated map and creates unknown paths, assuming the canonical `%{name}` form for keys with no captured placeholder map.

**Testing:** 14 new tests, 98.7% line coverage on the adapter — byte-for-byte round-trips with comments, both interpolation syntaxes, locale-root stripping/retargeting, sidecar reuse across languages, model-invented placeholders left literal, BCP-47 roots, and malformed input. Full suite 243 passing, lint clean, and I smoke-tested a real `.yml` through the built registry.

Stacked on #495 for the File formats table this adds a row to. No pipeline changes — its a registry addition, so it works across `translate` (file + folder), `diff`, and `check` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)