### PR TITLE
chore(action): modernize the composite action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,17 +1,28 @@
 name: i18n-ai-translate
-description: Automatically translate your i18n files (JSON, PO, .properties, .strings) on every PR with ChatGPT, Claude, Gemini, or Ollama
+description: Automatically translate your i18n files (JSON, PO, .properties, .strings, YAML, TS/JS) on every PR with ChatGPT, Claude, Gemini, or Ollama
 author: Taaha Mahdi
 
+branding:
+  icon: globe
+  color: purple
+
 inputs:
+  file-path:
+    description: 'Path to the source i18n file (JSON, PO, .properties, .strings, .yml, .ts, .js)'
+    required: false
   json-file-path:
-    description: 'Path to the source i18n JSON file'
-    required: true
+    description: 'Deprecated alias for file-path, kept for backwards compatibility'
+    required: false
   api-key:
     description: 'The API key'
     required: false
   host:
     description: "The ollama host and port number"
     required: false
+  version:
+    description: 'Version of i18n-ai-translate to run. Defaults to latest; pin to a version for reproducible runs'
+    required: false
+    default: 'latest'
   author-email:
     description: 'The email of the person to attribute the i18n change to'
     required: false
@@ -44,74 +55,144 @@ inputs:
     description: 'How many keys to process at a time'
     required: false
     default: 32
+  file-format:
+    description: 'Override the file format instead of inferring it from the extension (json, po, properties, strings, yaml, ts, js)'
+    required: false
+  context:
+    description: 'Product or domain context to steer translations (e.g. "a B2B invoicing SaaS")'
+    required: false
+  glossary:
+    description: 'Path to a glossary JSON file steering terminology'
+    required: false
+  node-version:
+    description: 'Node.js version used to run the CLI'
+    required: false
+    default: '22'
+  commit-message:
+    description: 'Commit message used for the translation commit'
+    required: false
+    default: 'Update translations'
 
 runs:
   using: 'composite'
   steps:
     - name: Check out Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
       with:
         ref: ${{ github.head_ref }}
         fetch-depth: 0
 
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v7
       with:
-        node-version: 18
+        node-version: ${{ inputs.node-version }}
+
+    # Inputs are passed through the environment rather than interpolated
+    # into the script body, so a value containing shell metacharacters
+    # cannot break out of the command.
+    - name: Resolve the input path
+      shell: bash
+      env:
+        FILE_PATH: ${{ inputs.file-path }}
+        LEGACY_FILE_PATH: ${{ inputs.json-file-path }}
+      run: |
+        resolved="${FILE_PATH:-$LEGACY_FILE_PATH}"
+        if [ -z "$resolved" ]; then
+          echo "::error::Set 'file-path' (or the deprecated 'json-file-path')."
+          exit 1
+        fi
+
+        if [ -n "$LEGACY_FILE_PATH" ] && [ -z "$FILE_PATH" ]; then
+          echo "::warning::'json-file-path' is deprecated; rename it to 'file-path'."
+        fi
+
+        if [ ! -f "$resolved" ]; then
+          echo "::error::No such file: $resolved"
+          exit 1
+        fi
+
+        echo "I18N_FILE_PATH=$resolved" >> "$GITHUB_ENV"
 
     - name: Fetch original translation
       shell: bash
       run: |
-        mv "${{ inputs.json-file-path }}" "${{ inputs.json-file-path }}-latest"
-        git checkout origin/${{ github.base_ref }} -- "${{ inputs.json-file-path }}"
+        mv "$I18N_FILE_PATH" "$I18N_FILE_PATH-latest"
+        git checkout "origin/$GITHUB_BASE_REF" -- "$I18N_FILE_PATH"
 
     - name: Translate the diff
       shell: bash
+      env:
+        API_KEY: ${{ inputs.api-key }}
+        HOST: ${{ inputs.host }}
+        VERSION: ${{ inputs.version }}
+        LANGUAGE: ${{ inputs.language }}
+        ENGINE: ${{ inputs.engine }}
+        MODEL: ${{ inputs.model }}
+        PREFIX: ${{ inputs.templated-string-prefix }}
+        SUFFIX: ${{ inputs.templated-string-suffix }}
+        BATCH_SIZE: ${{ inputs.batch-size }}
+        FILE_FORMAT: ${{ inputs.file-format }}
+        CONTEXT: ${{ inputs.context }}
+        GLOSSARY: ${{ inputs.glossary }}
       run: |
-        if [ -n "${{ inputs.api-key }}" ]; then
-          npx --yes i18n-ai-translate@latest diff \
-            -b "${{ inputs.json-file-path }}" \
-            -a "${{ inputs.json-file-path }}-latest" \
-            -l "${{ inputs.language }}" \
-            --verbose \
-            --engine "${{ inputs.engine }}" \
-            --model "${{ inputs.model }}" \
-            -p "${{ inputs.templated-string-prefix }}" \
-            -s "${{ inputs.templated-string-suffix }}" \
-            -n "${{ inputs.batch-size }}" \
-            -k "${{ inputs.api-key }}"
-        elif [ -n "${{ inputs.host }}" ]; then
-          npx --yes i18n-ai-translate@latest diff \
-            -b "${{ inputs.json-file-path }}" \
-            -a "${{ inputs.json-file-path }}-latest" \
-            -l "${{ inputs.language }}" \
-            --verbose \
-            --engine "${{ inputs.engine }}" \
-            --model "${{ inputs.model }}" \
-            -p "${{ inputs.templated-string-prefix }}" \
-            -s "${{ inputs.templated-string-suffix }}" \
-            -n "${{ inputs.batch-size }}" \
-            -h "${{ inputs.host }}"
-        else
-          echo "No API key or host specified; skipping automatic translation."
+        if [ -z "$API_KEY" ] && [ -z "$HOST" ]; then
+          echo "::warning::No API key or host specified; skipping automatic translation."
+          echo "I18N_SKIPPED=true" >> "$GITHUB_ENV"
+          exit 0
         fi
 
-        if [ $? -ne 0 ]; then
-          echo "Translation step failed" >&2
-          exit 1
-        fi
+        # The CLI reads the key from the environment, so it never appears
+        # in the process list or in a command echo.
+        case "$ENGINE" in
+          chatgpt) export OPENAI_API_KEY="$API_KEY" ;;
+          gemini) export GEMINI_API_KEY="$API_KEY" ;;
+          claude) export ANTHROPIC_API_KEY="$API_KEY" ;;
+        esac
 
-    - name: Configure Git
-      shell: bash
-      run: |
-        git config --global user.email "${{ inputs.author-email }}"
-        git config --global user.name "${{ inputs.author-name }}"
+        args=(diff
+          -b "$I18N_FILE_PATH"
+          -a "$I18N_FILE_PATH-latest"
+          -l "$LANGUAGE"
+          --verbose
+          --engine "$ENGINE"
+          --model "$MODEL"
+          -p "$PREFIX"
+          -s "$SUFFIX"
+          -n "$BATCH_SIZE"
+        )
+
+        if [ -n "$HOST" ]; then args+=(-h "$HOST"); fi
+        if [ -n "$FILE_FORMAT" ]; then args+=(--file-format "$FILE_FORMAT"); fi
+        if [ -n "$CONTEXT" ]; then args+=(--context "$CONTEXT"); fi
+        if [ -n "$GLOSSARY" ]; then args+=(--glossary "$GLOSSARY"); fi
+
+        # `shell: bash` runs with -e, so a non-zero exit here already
+        # fails the step.
+        npx --yes "i18n-ai-translate@$VERSION" "${args[@]}"
 
     - name: Commit the difference
       shell: bash
+      env:
+        AUTHOR_EMAIL: ${{ inputs.author-email }}
+        AUTHOR_NAME: ${{ inputs.author-name }}
+        COMMIT_MESSAGE: ${{ inputs.commit-message }}
       run: |
-        rm -r "${{ inputs.json-file-path }}"
-        mv "${{ inputs.json-file-path }}-latest" "${{ inputs.json-file-path }}"
+        rm -f "$I18N_FILE_PATH"
+        mv "$I18N_FILE_PATH-latest" "$I18N_FILE_PATH"
+
+        if [ "$I18N_SKIPPED" = "true" ]; then
+          echo "Translation was skipped; restored the source file without committing."
+          exit 0
+        fi
+
+        git config user.email "$AUTHOR_EMAIL"
+        git config user.name "$AUTHOR_NAME"
+
         git add --all
-        git commit -m "Update translations" || echo "No changes to commit"
+        if git diff --cached --quiet; then
+          echo "No changes to commit"
+          exit 0
+        fi
+
+        git commit -m "$COMMIT_MESSAGE"
         git push


### PR DESCRIPTION
The Action had drifted well behind both the CLI and the Actions platform.

### Versions
- `actions/checkout` v3 → v7, `actions/setup-node` v3 → v7. Both were far enough back to be on deprecated Node runtimes; newer checkout also carries the safer pull-request-checkout defaults.
- Node 18 → 22. Node 18 went EOL April 2025 (and 20 in April 2026), so the Action was pinned to an unsupported runtime. Now a `node-version` input rather than hard-coded.

### Hardening
Inputs now reach bash through `env:` instead of being interpolated into the script body. Previously `--model "${{ inputs.model }}"` pasted the raw value in *before* bash parsed it, so a value containing a quote and a semicolon ran as a command. I verified both the old shape and the new one: a model input of `gpt-5.2"; touch /tmp/PWNED; echo "` is now passed through as a single literal argument and nothing executes. This is defense-in-depth — inputs come from the calling workflow, so it is not remotely exploitable by default, but it is GitHub's recommended practice.

The API key now travels via the engine's environment variable (`OPENAI_API_KEY` / `GEMINI_API_KEY` / `ANTHROPIC_API_KEY`) rather than `-k` on the command line, so it cannot appear in a process list.

### Correctness
- Removed the `if [ $? -ne 0 ]` block — `shell: bash` runs with `-e`, so a failing npx already aborts the step and that check was unreachable.
- `rm -r` on a single file → `rm -f`.
- The commit step checks the staged tree first instead of relying on `|| echo`, so a no-op run does not error.
- A missing or empty file path now fails with a clear `::error::` instead of proceeding to `mv` a nonexistent file.
- The "no API key or host" path no longer falls through into the commit step.

### Catching up with the CLI
Adds `--file-format`, `--context`, and `--glossary` inputs, plus a `version` input so consumers can pin instead of always resolving `@latest`.

`json-file-path` becomes `file-path`, since the Action handles more than JSON now. **The old name still works** and emits a deprecation warning, so existing workflows are unaffected.

Adds `branding` so the Marketplace listing gets an icon.

### Testing
Every `run` block was syntax-checked and then executed against a stub `npx`: argument assembly across the key/host/optional-flag branches, multi-word values staying single arguments, the injection attempt above, both path-resolution fallbacks, and the commit step's skip / no-op / changed paths.

**What I could not test:** the Action end-to-end. That needs a real PR and an API key, and the version bumps in particular deserve one live run before this is tagged for the Marketplace.

Two follow-ups I deliberately left out: the README/guide still show `json-file-path` (which still works) — updating them here would collide with #498, so I would rather do it once both land. And `.github/workflows/build.yml` is still on `actions/checkout@v2` with Node 20; same class of fix, but out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)