### PR TITLE
chore: release 5.2.0 and fix what it would have published

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,14 @@
     "zod-to-json-schema": "^3.24.1"
   },
   "name": "i18n-ai-translate",
-  "version": "5.1.0",
+  "version": "5.2.0",
+  "files": [
+    "build",
+    "!build/test",
+    "!build/types/test",
+    "src",
+    "!src/test"
+  ],
   "main": "./build/index.js",
   "types": "./build/types/index.d.ts",
   "bin": {
@@ -53,7 +60,7 @@
   },
   "scripts": {
     "build": "npx tsc",
-    "prepare": "npm run build && npx esbuild src/cli.ts --bundle --platform=node --outfile=build/i18n-ai-translate.js --banner:js='#!/usr/bin/env node'",
+    "prepare": "npm run build && npx esbuild src/cli.ts --bundle --platform=node --outfile=build/i18n-ai-translate.js --external:typescript --banner:js='#!/usr/bin/env node'",
     "i18n-ai-translate": "npm run build && node build/cli.js",
     "clean": "rm -r build/ && rm tsconfig.tsbuildinfo",
     "clean-build": "npm run clean && npm run build",


### PR DESCRIPTION
Bumps `5.1.0` → `5.2.0`. Per the release convention only `package.json` changes — `VERSION` in `constants.ts` imports it.

**Unreleased since 5.1.0:** the Rails YAML adapter (#496), JS/TS locale modules (#497), the guide fixes (#495), the searchable npm metadata (#498), and the modernized Action (#499). Worth noting the metadata does nothing until a publish happens — the registry still serves 5.1.0's description, *"Use LLMs to translate your i18n JSON to any language."* And the modernized Action offers `--file-format yaml|ts|js` while resolving `npx i18n-ai-translate@latest`, which today is 5.1.0 and cannot handle those values.

While verifying the tarball I found two things this release should not ship without.

### 1. npm was publishing private files

npm warns that it falls back to `.gitignore` when no `.npmignore` exists, which only excludes what git ignores. Everything else was going into the tarball:

```
.claude/prompt-audit.md   .claude/refactor-notes.md   .claude/settings.local.json
BUG_REPORT.md   CLAUDE.md   FORMATS_PLAN.md   README-jsons.md
```

plus the entire test suite — 358 files, 19.4MB unpacked. `.env` and `jsons/` were never included, so no credential was ever at risk (I checked those files for credential-shaped content and local paths: zero matches), but the working notes would have gone public permanently, since npm blocks unpublishing after 72h.

Replaced the `.gitignore` fallback with an explicit `files` allowlist.

### 2. The CLI bundle had doubled

7.6MB → 18.0MB. `import ts from "typescript"` in the module adapter pulls the whole TypeScript compiler into the esbuild output — I confirmed by building the bundle at the commit before #497 and comparing. `--external:typescript` restores 7.6MB; typescript is already a runtime dependency so it resolves from `node_modules` at execution.

**Net: 358 files / 19.4MB → 244 files / 8.8MB unpacked.**

### Verification

Rather than trusting `--dry-run`, I packed the tarball, installed it into a clean project, and ran it:

- bin executes and reports `5.2.0` — proving the externalized `typescript` resolves at runtime
- library entrypoint exports all seven public functions
- registry lists all seven formats; `en.ts` → `ts`, `en.yml` → `yaml`
- none of the private files are present
- 256 tests pass, lint clean

### One trap for whoever publishes

Run `npm run clean-build` first. `tsc` is incremental, so a stale `tsconfig.tsbuildinfo` beside a deleted `build/` makes `prepare` emit almost nothing — my first tarball had **no `build/index.js`**, i.e. a broken library entrypoint, and nothing failed loudly. Since `npm publish` runs `prepare`, publishing from a dirty working directory can silently ship an incomplete package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)