### PR TITLE
ci: publish to npm via trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: release
+
+# Publishes to npm via trusted publishing (OIDC) — no NPM_TOKEN needed.
+# Requires a Trusted Publisher configured on npmjs.com for this package,
+# matching the repo owner, repo name, and this workflow's filename
+# (release.yml).
+#
+# Release flow:
+#   1. Merge a PR bumping "version" in package.json
+#   2. git tag v<version> && git push origin v<version>
+# The tag push runs this workflow, which refuses to publish if the tag
+# and package.json disagree, or if the version is already on the registry.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Required for OIDC: lets the runner mint the identity token npm
+  # exchanges for short-lived publish credentials.
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Use Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      # Node 22 bundles npm 10.x; trusted publishing needs >= 11.5.1.
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Ensure unit tests pass
+        run: npm run test
+
+      - name: Verify tag matches package.json version
+        if: github.event_name == 'push'
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(node -p "require('./package.json').version")"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME implies $tag but package.json says $pkg"
+            exit 1
+          fi
+          echo "Tag and package.json agree on $pkg"
+
+      - name: Verify this version is not already published
+        run: |
+          pkg="$(node -p "require('./package.json').version")"
+          if npm view "i18n-ai-translate@$pkg" version >/dev/null 2>&1; then
+            echo "::error::$pkg is already on the registry; bump the version first"
+            exit 1
+          fi
+          echo "$pkg is unpublished; proceeding"
+
+      # No NODE_AUTH_TOKEN: npm exchanges the OIDC identity token for
+      # short-lived credentials. `prepare` builds as part of publish.
+      - name: Publish to npm
+        run: npm publish


### PR DESCRIPTION
Publishing 5.2.0 required a 2FA prompt that cannot be answered over SSH, and the workaround — a Bypass-2FA token — is on npm's deprecation path: [those tokens lost account and package management in July 2026](https://github.blog/changelog/2026-07-31-restricting-npm-bypass-2fa-granular-access-tokens/), and [lose direct publish in January 2027](https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/).

[Trusted publishing](https://docs.npmjs.com/trusted-publishers/) removes the token entirely. The runner mints a short-lived OIDC identity that npm exchanges for publish credentials, so there is no `NODE_AUTH_TOKEN` — nothing to store, rotate, or leak — and releases no longer depend on which machine you are sitting at.

### Release flow

1. Merge a PR bumping `version` in `package.json`
2. `git tag v<version> && git push origin v<version>`

### Guards

A tag push is easy to get wrong, so two checks run before publish:

- **Tag must match `package.json`.** Pushing `v5.3.0` against a tree that still says `5.2.0` fails loudly instead of publishing the wrong thing.
- **Version must not already be on the registry.** Fails fast with a clear message rather than npm's opaque error.

### Repo-specific details

- Installs with **yarn** to match `build.yml` — there is no `package-lock.json`, so `npm ci` would fail.
- Upgrades npm explicitly: Node 22 bundles npm 10.x, and trusted publishing needs >= 11.5.1.

### Testing

YAML parses, both guard scripts syntax-check, and I executed both against real conditions rather than eyeballing them:

| Case | Result |
|---|---|
| Tag `v5.3.0` vs package.json `5.2.0` | fails ✓ |
| Tag `v5.2.0` vs package.json `5.2.0` | passes ✓ |
| Version `5.2.0` (already published) | rejected ✓ |
| Version `99.0.0` (unpublished) | proceeds ✓ |

**Not tested end-to-end** — that needs a real tag push, and it cannot work until the Trusted Publisher exists on npmjs.com. Treat 5.3.0 as the shakedown release.

### Required before this works

Configure a Trusted Publisher on the npmjs.com package page (Settings → Trusted Publisher). There is no CLI or API for this:

| Field | Value |
|---|---|
| Provider | GitHub Actions |
| Organization/owner | `taahamahdi` (case-sensitive) |
| Repository | `i18n-ai-translate` |
| Workflow filename | `release.yml` |

Configurations created after May 2026 also require explicitly selecting at least one allowed action — choose publish. A 404 on publish almost always means npm could not match the run to this config, usually a case-sensitivity or filename mismatch.

Once a release goes through this way, both npm tokens can be revoked and not replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)