### PR TITLE
fix(action): shorten description under the Marketplace limit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: i18n-ai-translate
-description: Automatically translate your i18n files (JSON, PO, .properties, .strings, YAML, TS/JS) on every PR with ChatGPT, Claude, Gemini, or Ollama
+description: Auto-translate i18n files on every PR with ChatGPT, Claude, Gemini, or Ollama - JSON, PO, YAML, TS/JS
 author: Taaha Mahdi
 
 branding:


### PR DESCRIPTION
GitHub Marketplace requires `action.yml`'s `description` to be under 125 characters. Ours was **138**, which blocks publishing the listing.

Now **101 characters**:

> Auto-translate i18n files on every PR with ChatGPT, Claude, Gemini, or Ollama - JSON, PO, YAML, TS/JS

Keeps the engine names and the format list, since those are what people search the Marketplace for. Trimmed `.properties`/`.strings` from the enumeration rather than dropping either category entirely.

Note this limit applies only to `action.yml`. The npm `description` and the GitHub repo description are separate fields with their own (much longer) limits, and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)