### PR TITLE
feat(formats): translate ICU MessageFormat / next-intl catalogues

### DIFF
--- a/ADVANCED_GUIDE.md
+++ b/ADVANCED_GUIDE.md
@@ -37,8 +37,15 @@ Every format goes through the same pipeline: an adapter parses the file into the
 | `yaml` | `.yml`, `.yaml` | Comments, key order, quoting/block style | `%{name}`, `%<name>s` |
 | `ts` | `.ts`, `.mts`, `.cts` | Imports, comments, types, `satisfies`/`as const` | `{{var}}` (native) |
 | `js` | `.js`, `.mjs`, `.cjs` | Imports, comments, module shape | `{{var}}` (native) |
+| `icu` | *(opt-in, no extension)* | Key order, non-string values, message structure | `{name}`, `{n, number, …}`, `#` |
 
 The format is inferred from the file extension; pass `--file-format` to override. All formats work across `translate` (file and directory), `diff`, and `check`.
+
+**ICU MessageFormat / next-intl.** Opt in with `--file-format icu`; it is deliberately *not* bound to `.json`, so existing i18next catalogues are unaffected. Arguments become `{{var}}` placeholders so the usual protection applies, and their original syntax — including number skeletons like `::currency/USD` — is restored verbatim on write. Rich-text tags such as `<link>…</link>` stay inline so the model translates a readable sentence.
+
+Plural and select messages are expanded into one **whole sentence per branch**, not fragments: `You have {count, plural, one {# item} other {# items}} left` is translated as *"You have {{#}} item left"* and *"You have {{#}} items left"*. That gives the model full context, and lets a target language order words differently in each plural form. On write the branches are re-assembled against the **target** language's CLDR categories, so an English `one`/`other` source produces `one`/`few`/`many`/`other` for Russian. Exact matches like `=0` are carried across untouched.
+
+Two limits worth knowing. Categories the source doesn't supply are filled from `other` — structurally valid but not correctly inflected, the same approximation the PO adapter makes; review those branches. And messages with nested or multiple plural/select blocks are passed through **untranslated** rather than risk mangling them. A rebuilt message that fails to re-parse is discarded in favour of the original, so a bad translation can never produce a catalogue that throws at runtime.
 
 **JS/TS locale modules.** The catalogue is located as `export default {…}`, `export = {…}`, `module.exports = {…}`, an exported `const` holding an object literal, or — if the file has exactly one — a bare top-level `const`. Only plain string literals are translated, in whatever quote style they were written; numbers, template literals containing `${…}`, function calls, and computed keys are skipped and their bytes preserved. The exported binding is *not* renamed, so a `fr.ts` produced from `en.ts` still exports `enTranslations` if that is what the source called it.
 
@@ -167,7 +174,7 @@ Options:
   --exclude-languages [language codes...]     Language codes to skip
   --tokens-per-minute <tpm>                   Cap tokens-per-minute across all concurrent workers (disabled by default)
   --language-concurrency <n>                  How many target languages to translate in parallel (default: 1)
-  --file-format <format>                      json, po, properties, strings, yaml, ts, js (default: inferred from extension)
+  --file-format <format>                      json, po, properties, strings, yaml, ts, js, icu (default: inferred from extension)
   --cache [path]                              Reuse a translation memory across runs (default: .i18n-ai-translate-cache.json)
   --glossary <path>                           Path to a glossary JSON file steering terminology
   --help                                      display help for command
@@ -231,7 +238,7 @@ Options:
   --context <context>                       Domain context
   --exclude-languages [language codes...]   Locales to skip
   --tokens-per-minute <tpm>                 TPM cap
-  --file-format <format>                    json, po, properties, strings, yaml, ts, js (default: from extension)
+  --file-format <format>                    json, po, properties, strings, yaml, ts, js, icu (default: from extension)
   --cache [path]                            Reuse a translation memory across runs
   --glossary <path>                         Glossary JSON file steering terminology
   --help                                    display help for command
@@ -277,7 +284,7 @@ Options:
   --context <context>                         Domain context
   --tokens-per-minute <tpm>                   TPM cap
   --format <format>                           'table' (default) or 'json'
-  --file-format <format>                      json, po, properties, strings, yaml, ts, js (default: from extension)
+  --file-format <format>                      json, po, properties, strings, yaml, ts, js, icu (default: from extension)
   --help                                      display help for command
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **Auto-translate i18n JSON and other locale files using AI.** Point it at one file or a whole directory and it machine-translates your app into any language with ChatGPT, Gemini, Claude, or local Ollama models — keeping translations accurate, formatting consistent, and placeholders intact.
 
-Works with **i18next-style JSON** out of the box, plus Gettext `.po`, Java `.properties`, iOS `.strings`, Rails YAML, and JS/TS locale modules. Use it as a **CLI**, a **Node library**, or a **GitHub Action** that translates every pull request automatically.
+Works with **i18next-style JSON** out of the box, plus Gettext `.po`, Java `.properties`, iOS `.strings`, Rails YAML, JS/TS locale modules, and ICU MessageFormat (next-intl). Use it as a **CLI**, a **Node library**, or a **GitHub Action** that translates every pull request automatically.
 
 _For a detailed walkthrough and advanced tips, see [ADVANCED_GUIDE.md](ADVANCED_GUIDE.md)._
 
@@ -22,7 +22,7 @@ _For a detailed walkthrough and advanced tips, see [ADVANCED_GUIDE.md](ADVANCED_
 | **Safe**              | Translations verified against the source before being written                           |
 | **Diff-aware**        | Only re-translate keys you changed; existing translations are preserved                 |
 | **Check mode**        | Audit existing translations for drift, missing placeholders, or quality regressions     |
-| **Format-aware**      | i18next JSON, Gettext `.po`, Java `.properties`, iOS `.strings`, Rails `.yml`, JS/TS modules — round-tripped intact |
+| **Format-aware**      | i18next JSON, Gettext `.po`, Java `.properties`, iOS `.strings`, Rails `.yml`, JS/TS modules, ICU/next-intl — round-tripped intact |
 | **Context-aware**     | `--context` flag injects product info so the model picks domain-appropriate terminology |
 | **Dry-run**           | Preview updates before touching disk                                                    |
 | **Everywhere**        | Use as a CLI, GitHub Action, or Node library                                            |
@@ -47,7 +47,7 @@ i18n-ai-translate translate -i i18n/en.json -o fr \
 
 Need more languages? Pass multiple codes (`-o fr es de`) or `-A` for **all** 180+. Filenames like `es-ES.json` / `pt-BR.json` are accepted too — the language subtag is extracted automatically. Skip specific locales with `--exclude-languages fr de` (handy for locales you maintain by hand).
 
-**Other formats:** besides i18next JSON, Gettext `.po`, Java `.properties`, iOS `.strings`, Rails `.yml`/`.yaml`, and JavaScript/TypeScript locale modules (`.ts`, `.js`, `.mjs`, `.cjs`, `.mts`, `.cts`) work too — the format is inferred from the file extension (override with `--file-format json|po|properties|strings|yaml|ts|js`). Non-translatable structure round-trips losslessly: PO comments, `msgctxt`, and plural forms; `.properties` comments, separators, and line continuations; `.strings` `/* */` and `//` comments and quoting; YAML comments, key order, and quoting style; JS/TS imports, comments, type annotations, and `satisfies`/`as const` clauses. Native placeholders (`printf` `%s`/`%1$s`/`%@`, MessageFormat `{0}`/`{1}`, Rails `%{name}`/`%<name>s`) are preserved across the translation. Works across `translate` (file + folder), `diff`, and `check`.
+**Other formats:** besides i18next JSON, Gettext `.po`, Java `.properties`, iOS `.strings`, Rails `.yml`/`.yaml`, and JavaScript/TypeScript locale modules (`.ts`, `.js`, `.mjs`, `.cjs`, `.mts`, `.cts`) work too — the format is inferred from the file extension (override with `--file-format json|po|properties|strings|yaml|ts|js|icu`). Non-translatable structure round-trips losslessly: PO comments, `msgctxt`, and plural forms; `.properties` comments, separators, and line continuations; `.strings` `/* */` and `//` comments and quoting; YAML comments, key order, and quoting style; JS/TS imports, comments, type annotations, and `satisfies`/`as const` clauses. Native placeholders (`printf` `%s`/`%1$s`/`%@`, MessageFormat `{0}`/`{1}`, Rails `%{name}`/`%<name>s`) are preserved across the translation. Works across `translate` (file + folder), `diff`, and `check`.
 
 For a JS/TS module, the catalogue is found as `export default {…}`, `module.exports = {…}`, or an exported `const` holding an object literal, and only plain string literals are translated — numbers, template literals with `${…}` substitutions, and computed keys are left exactly as written. Rails YAML files may be locale-rooted (`en:` at the top level); the root key is retargeted to the output language on write, so `en.yml` → `fr.yml` gets `fr:`.
 
@@ -57,6 +57,15 @@ en:                               fr:
   greeting: Hello                   greeting: Bonjour
   inbox:                            inbox:
     unread: "%{count} unread"         unread: "%{count} non lus"
+```
+
+**ICU MessageFormat / next-intl:** pass `--file-format icu` (it is not bound to `.json`, so i18next catalogues are untouched). Plural and select messages are translated as whole sentences per branch and re-assembled against the target language's CLDR categories, so English `one`/`other` becomes `one`/`few`/`many`/`other` in Russian:
+
+```json
+// en.json                                          fr.json, after --file-format icu -o fr
+"items": "You have {count, plural,                  "items": "{count, plural,
+  one {# item} other {# items}} left"                 one {Il reste # article}
+                                                      other {Il reste # articles}}"
 ```
 
 ### 3 · Translate a folder
@@ -125,7 +134,7 @@ Common flags (all subcommands accept these unless noted):
 | `--no-continue-on-error`  | continue        | Abort on first key/batch failure instead of skipping                            |
 | `--dry-run`               | false           | Don't write files, preview instead (translate/diff only)                        |
 | `--cache [path]`          | off             | Reuse a translation memory across runs; skip unchanged strings (translate/diff) |
-| `--file-format`           | from extension  | File format: `json`, `po`, `properties`, `strings`, `yaml`, `ts`, `js` (translate/diff/check) |
+| `--file-format`           | from extension  | File format: `json`, `po`, `properties`, `strings`, `yaml`, `ts`, `js`, `icu` (translate/diff/check) |
 | `--format`                | table           | `table` or `json` report output (check only)                                    |
 
 Full flag list: `i18n-ai-translate <subcommand> --help`.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.92.0",
     "@google/generative-ai": "^0.24.0",
+    "@messageformat/parser": "^5.1.1",
     "@types/flat": "^5.0.5",
     "@types/node": "^24.0.3",
     "ansi-colors": "^4.1.3",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,7 +36,7 @@ export const CLI_HELP = {
     ExcludeLanguages:
         "Language codes to skip (e.g. 'fr de'). Useful when some locales are maintained manually and shouldn't be machine-translated over",
     FileFormat:
-        "Input/output file format (default: inferred from extension). Supported: json, po, properties, strings, yaml, ts, js.",
+        "Input/output file format (default: inferred from extension). Supported: json, po, properties, strings, yaml, ts, js, icu.",
     Glossary:
         "Path to a glossary JSON file steering terminology: { \"doNotTranslate\": [\"Acme\"], \"terms\": { \"fr\": { \"Account\": \"Compte\" } } }. Injected into the generation and verification prompts",
     LanguageConcurrency:

--- a/src/formats/icu_adapter.ts
+++ b/src/formats/icu_adapter.ts
@@ -1,0 +1,412 @@
+import { FLATTEN_DELIMITER } from "../constants";
+import { type Select, type Token, parse } from "@messageformat/parser";
+import { flatten, unflatten } from "flat";
+import { getPluralRule } from "./po_plural_rules";
+import type FormatAdapter from "./format_adapter";
+
+/**
+ * Placeholder standing in for ICU's octothorpe (`#`, the formatted
+ * plural number). Wrapped in the pipeline's `{{…}}` convention so the
+ * prompts' existing "never translate a placeholder" rule covers it.
+ */
+const POUND_PLACEHOLDER = "{{#}}";
+
+/** Suffix marking an expanded `select` branch in a flat key. */
+const SELECT_SUFFIX = "_select_";
+
+/**
+ * Original ICU source for each argument, keyed by the placeholder that
+ * replaced it. Rebuilding a currency skeleton from its parsed parts is
+ * easy to get subtly wrong, so the exact source text is recorded
+ * instead and substituted back verbatim.
+ */
+type ArgSources = Record<string, string>;
+
+type ICUEntry =
+    | { kind: "plain"; key: string; argSources: ArgSources; original: string }
+    | {
+          kind: "control";
+          key: string;
+          /** `plural`, `selectordinal`, or `select`. */
+          type: Select["type"];
+          arg: string;
+          offset: number | undefined;
+          /** Case keys in source order, e.g. `["one", "other"]`. */
+          categories: string[];
+          argSources: ArgSources;
+          /** What `read` produced per suffix, to detect "nothing changed". */
+          rendered: Record<string, string>;
+          original: string;
+      }
+    /** Non-string JSON values, and messages too complex to split safely. */
+    | { kind: "passthrough"; key: string; value: unknown };
+
+type ICUSidecar = {
+    kind: "icu";
+    entries: ICUEntry[];
+};
+
+const CONTROL_TYPES = new Set(["plural", "selectordinal", "select"]);
+
+function isControl(token: Token): token is Select {
+    return CONTROL_TYPES.has(token.type);
+}
+
+/**
+ * True when any token below this one is a plural/select. Nesting needs a
+ * combinatorial expansion, so v1 passes those messages through rather
+ * than risk mangling them.
+ * @param tokens - tokens to scan
+ * @returns whether a nested control exists
+ */
+function hasNestedControl(tokens: Token[]): boolean {
+    return tokens.some(isControl);
+}
+
+/**
+ * Reconstruct a function argument's ICU source, e.g.
+ * `{amount, number, ::currency/USD}`. Returns undefined when the style
+ * contains anything but literal text, which the caller treats as a
+ * reason to pass the whole message through untouched.
+ * @param token - the function-argument token
+ * @returns the ICU source, or undefined
+ */
+function functionSource(
+    token: Token & { type: "function" },
+): string | undefined {
+    if (!token.param || token.param.length === 0) {
+        return `{${token.arg}, ${token.key}}`;
+    }
+
+    let param = "";
+    for (const part of token.param) {
+        if (part.type !== "content") return undefined;
+        param += part.value;
+    }
+
+    return `{${token.arg}, ${token.key},${param}}`;
+}
+
+/**
+ * Render tokens into the flat string the pipeline translates.
+ *
+ * Arguments become `{{name}}` so existing placeholder protection
+ * applies. Rich-text tags arrive as literal content and stay inline,
+ * which keeps the sentence readable and is what models handle best.
+ * @param tokens - tokens to render
+ * @param argSources - accumulator mapping placeholder to ICU source
+ * @returns the translatable string, or undefined if unrenderable
+ */
+function render(tokens: Token[], argSources: ArgSources): string | undefined {
+    let out = "";
+    for (const token of tokens) {
+        switch (token.type) {
+            case "content":
+                out += token.value;
+                break;
+            case "octothorpe":
+                out += POUND_PLACEHOLDER;
+                break;
+            case "argument":
+                argSources[`{{${token.arg}}}`] = `{${token.arg}}`;
+                out += `{{${token.arg}}}`;
+                break;
+            case "function": {
+                const source = functionSource(token);
+                if (source === undefined) return undefined;
+                argSources[`{{${token.arg}}}`] = source;
+                out += `{{${token.arg}}}`;
+                break;
+            }
+
+            default:
+                // A control token: callers expand these before rendering.
+                return undefined;
+        }
+    }
+
+    return out;
+}
+
+/**
+ * Invert `render`: turn a translated string back into ICU source.
+ * @param text - the translated string
+ * @param argSources - placeholder to ICU source
+ * @returns ICU message source
+ */
+function restore(text: string, argSources: ArgSources): string {
+    let out = text;
+    for (const [placeholder, source] of Object.entries(argSources)) {
+        out = out.split(placeholder).join(source);
+    }
+
+    out = out.split(POUND_PLACEHOLDER).join("#");
+    // A placeholder the model invented has no recorded source; emit a
+    // bare ICU argument so the message still parses.
+    return out.replace(/\{\{([^{}]+)\}\}/g, "{$1}");
+}
+
+/**
+ * Guard against writing a catalogue that throws in the user's app: only
+ * return the rebuilt message if it actually parses.
+ * @param body - candidate ICU source
+ * @returns the source if valid, else undefined
+ */
+function validated(body: string): string | undefined {
+    try {
+        parse(body);
+        return body;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Exact matches are language-independent and always kept.
+ * @param key - a plural case key
+ * @returns whether the key is an exact match rather than a category
+ */
+function isExactCase(key: string): boolean {
+    return key.startsWith("=");
+}
+
+const ICUAdapter: FormatAdapter<ICUSidecar> = {
+    // Registered by name only: `.json` stays with the i18next adapter so
+    // existing users are unaffected. ICU is opt-in via --file-format icu.
+    extensions: [] as const,
+    name: "icu",
+
+    read(raw: string): { flat: Record<string, string>; sidecar: ICUSidecar } {
+        const parsed = JSON.parse(raw);
+        const flatSource = flatten(parsed, {
+            delimiter: FLATTEN_DELIMITER,
+        }) as Record<string, unknown>;
+
+        const flat: Record<string, string> = {};
+        const entries: ICUEntry[] = [];
+
+        for (const [key, value] of Object.entries(flatSource)) {
+            if (typeof value !== "string") {
+                entries.push({ key, kind: "passthrough", value });
+                continue;
+            }
+
+            let tokens: Token[];
+            try {
+                tokens = parse(value);
+            } catch {
+                // Not valid ICU. Treat it as plain text so one odd string
+                // can't fail the whole run.
+                entries.push({
+                    argSources: {},
+                    key,
+                    kind: "plain",
+                    original: value,
+                });
+                flat[key] = value;
+                continue;
+            }
+
+            const controls = tokens.filter(isControl);
+
+            if (controls.length === 0) {
+                const argSources: ArgSources = {};
+                const rendered = render(tokens, argSources);
+                if (rendered === undefined) {
+                    entries.push({ key, kind: "passthrough", value });
+                    continue;
+                }
+
+                entries.push({
+                    argSources,
+                    key,
+                    kind: "plain",
+                    original: value,
+                });
+                flat[key] = rendered;
+                continue;
+            }
+
+            const control = controls[0];
+            const nested = control.cases.some((c) =>
+                hasNestedControl(c.tokens),
+            );
+
+            if (controls.length > 1 || nested) {
+                entries.push({ key, kind: "passthrough", value });
+                continue;
+            }
+
+            // Each branch is rendered as the *whole* sentence with that
+            // branch selected, so the model sees complete text rather
+            // than fragments — and target languages can order words
+            // differently per plural form.
+            const argSources: ArgSources = {};
+            const rendered: Record<string, string> = {};
+            const categories: string[] = [];
+            let renderable = true;
+
+            for (const branch of control.cases) {
+                const expanded = tokens.flatMap((token) =>
+                    token === control ? branch.tokens : [token],
+                );
+
+                const text = render(expanded, argSources);
+                if (text === undefined) {
+                    renderable = false;
+                    break;
+                }
+
+                const suffix =
+                    control.type === "select"
+                        ? `${SELECT_SUFFIX}${branch.key}`
+                        : `_${branch.key}`;
+
+                categories.push(branch.key);
+                rendered[suffix] = text;
+            }
+
+            if (!renderable) {
+                entries.push({ key, kind: "passthrough", value });
+                continue;
+            }
+
+            for (const [suffix, text] of Object.entries(rendered)) {
+                flat[`${key}${suffix}`] = text;
+            }
+
+            entries.push({
+                arg: control.arg,
+                argSources,
+                categories,
+                key,
+                kind: "control",
+                offset: control.pluralOffset,
+                original: value,
+                rendered,
+                type: control.type,
+            });
+        }
+
+        return { flat, sidecar: { entries, kind: "icu" } };
+    },
+
+    write(
+        translated: Record<string, string>,
+        sidecar: ICUSidecar,
+        _inputLanguageCode: string,
+        outputLanguageCode: string,
+    ): string {
+        const out: Record<string, unknown> = {};
+
+        for (const entry of sidecar.entries) {
+            if (entry.kind === "passthrough") {
+                out[entry.key] = entry.value;
+                continue;
+            }
+
+            if (entry.kind === "plain") {
+                const value = translated[entry.key];
+                out[entry.key] =
+                    value === undefined
+                        ? entry.original
+                        : (validated(restore(value, entry.argSources)) ??
+                          entry.original);
+                continue;
+            }
+
+            // Untouched: hand back the exact source so a partially
+            // translated catalogue keeps unchanged entries byte-for-byte.
+            const untouched = Object.entries(entry.rendered).every(
+                ([suffix, text]) => {
+                    const value = translated[`${entry.key}${suffix}`];
+                    return value === undefined || value === text;
+                },
+            );
+
+            if (untouched) {
+                out[entry.key] = entry.original;
+                continue;
+            }
+
+            const branches: string[] = [];
+
+            if (entry.type === "select") {
+                for (const category of entry.categories) {
+                    const value =
+                        translated[`${entry.key}${SELECT_SUFFIX}${category}`];
+
+                    if (value === undefined) break;
+                    branches.push(
+                        `${category} {${restore(value, entry.argSources)}}`,
+                    );
+                }
+
+                out[entry.key] =
+                    branches.length === entry.categories.length
+                        ? (validated(
+                              `{${entry.arg}, select, ${branches.join(" ")}}`,
+                          ) ?? entry.original)
+                        : entry.original;
+                continue;
+            }
+
+            // Exact matches (`=0`) are language-independent, so they are
+            // carried across verbatim rather than mapped onto categories.
+            for (const category of entry.categories.filter(isExactCase)) {
+                const value = translated[`${entry.key}_${category}`];
+                if (value === undefined) continue;
+                branches.push(
+                    `${category} {${restore(value, entry.argSources)}}`,
+                );
+            }
+
+            // ICU *requires* an `other` branch, while the Gettext table is
+            // index-based and omits it for languages like Russian
+            // (one/few/many). Without this union the message is invalid
+            // and would be rejected, silently leaving it untranslated.
+            const targetCategories = [
+                ...new Set([
+                    ...getPluralRule(outputLanguageCode).categories,
+                    "other",
+                ]),
+            ];
+
+            // The source rarely has every category the target needs, so
+            // missing ones reuse `other`: structurally valid, but not
+            // correctly inflected. See the guide's note.
+            const fallback = translated[`${entry.key}_other`];
+            let complete = true;
+
+            for (const category of targetCategories) {
+                const value =
+                    translated[`${entry.key}_${category}`] ?? fallback;
+
+                if (value === undefined) {
+                    complete = false;
+                    break;
+                }
+
+                branches.push(
+                    `${category} {${restore(value, entry.argSources)}}`,
+                );
+            }
+
+            if (!complete) {
+                out[entry.key] = entry.original;
+                continue;
+            }
+
+            const offset = entry.offset ? `offset:${entry.offset} ` : "";
+            out[entry.key] =
+                validated(
+                    `{${entry.arg}, ${entry.type}, ${offset}${branches.join(" ")}}`,
+                ) ?? entry.original;
+        }
+
+        const unflattened = unflatten(out, { delimiter: FLATTEN_DELIMITER });
+        return `${JSON.stringify(unflattened, null, 4)}\n`;
+    },
+};
+
+export default ICUAdapter;

--- a/src/formats/registry.ts
+++ b/src/formats/registry.ts
@@ -1,3 +1,4 @@
+import ICUAdapter from "./icu_adapter";
 import JSONAdapter from "./json_adapter";
 import POAdapter from "./po_adapter";
 import PropertiesAdapter from "./properties_adapter";
@@ -18,6 +19,7 @@ const ADAPTERS: readonly FormatAdapter<unknown>[] = [
     YAMLAdapter,
     TypeScriptAdapter,
     JavaScriptAdapter,
+    ICUAdapter,
 ];
 
 /**

--- a/src/test/formats.spec.ts
+++ b/src/test/formats.spec.ts
@@ -8,6 +8,7 @@ import { po } from "gettext-parser";
 import JSONAdapter from "../formats/json_adapter";
 import POAdapter from "../formats/po_adapter";
 import PropertiesAdapter from "../formats/properties_adapter";
+import ICUAdapter from "../formats/icu_adapter";
 import StringsAdapter from "../formats/strings_adapter";
 import TypeScriptAdapter, {
     JavaScriptAdapter,
@@ -18,27 +19,27 @@ import YAMLAdapter from "../formats/yaml_adapter";
 const SEP = "\x1e";
 
 const PO_FIXTURE = [
-    "msgid \"\"",
-    "msgstr \"\"",
-    "\"Content-Type: text/plain; charset=UTF-8\\n\"",
-    "\"Plural-Forms: nplurals=2; plural=(n != 1);\\n\"",
-    "\"Language: en\\n\"",
+    'msgid ""',
+    'msgstr ""',
+    '"Content-Type: text/plain; charset=UTF-8\\n"',
+    '"Plural-Forms: nplurals=2; plural=(n != 1);\\n"',
+    '"Language: en\\n"',
     "",
     "# translator comment",
     "#. extracted comment",
     "#: src/app.js:42",
     "#, javascript-format",
-    "msgid \"Hello %s\"",
-    "msgstr \"\"",
+    'msgid "Hello %s"',
+    'msgstr ""',
     "",
-    "msgctxt \"menu\"",
-    "msgid \"Save\"",
-    "msgstr \"\"",
+    'msgctxt "menu"',
+    'msgid "Save"',
+    'msgstr ""',
     "",
-    "msgid \"One item\"",
-    "msgid_plural \"%d items\"",
-    "msgstr[0] \"\"",
-    "msgstr[1] \"\"",
+    'msgid "One item"',
+    'msgid_plural "%d items"',
+    'msgstr[0] ""',
+    'msgstr[1] ""',
     "",
 ].join("\n");
 
@@ -96,6 +97,14 @@ describe("format registry", () => {
         expect(getAdapterForFile("en.cjs")).toBe(JavaScriptAdapter);
     });
 
+    it("resolves the ICU adapter by name only, never by extension", () => {
+        expect(getAdapterByName("icu")).toBe(ICUAdapter);
+        // Critical: .json must keep resolving to the i18next adapter so
+        // existing users are unaffected. ICU is opt-in.
+        expect(getAdapterForFile("en.json")).toBe(JSONAdapter);
+        expect(getAdapterByExtension(".json")).toBe(JSONAdapter);
+    });
+
     it("lists registered format names", () => {
         expect(listFormatNames()).toEqual([
             "json",
@@ -105,6 +114,7 @@ describe("format registry", () => {
             "yaml",
             "ts",
             "js",
+            "icu",
         ]);
     });
 });
@@ -153,13 +163,13 @@ describe("POAdapter", () => {
 
     it("normalizes positional placeholders and restores them on write", () => {
         const fixture = [
-            "msgid \"\"",
-            "msgstr \"\"",
-            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
-            "\"Language: en\\n\"",
+            'msgid ""',
+            'msgstr ""',
+            '"Content-Type: text/plain; charset=UTF-8\\n"',
+            '"Language: en\\n"',
             "",
-            "msgid \"%1$s sent %2$s\"",
-            "msgstr \"\"",
+            'msgid "%1$s sent %2$s"',
+            'msgstr ""',
             "",
         ].join("\n");
 
@@ -168,9 +178,9 @@ describe("POAdapter", () => {
 
         const output = POAdapter.write(flat, sidecar, "en", "en");
         const reparsed = po.parse(output);
-        expect(
-            reparsed.translations[""]["%1$s sent %2$s"].msgstr[0],
-        ).toBe("%1$s sent %2$s");
+        expect(reparsed.translations[""]["%1$s sent %2$s"].msgstr[0]).toBe(
+            "%1$s sent %2$s",
+        );
     });
 
     it("round-trips through write: fills msgstr, restores placeholders, preserves comments", () => {
@@ -230,15 +240,15 @@ describe("POAdapter", () => {
 
     it("leaves a %% literal untouched on read and write", () => {
         const fixture = [
-            "msgid \"\"",
-            "msgstr \"\"",
-            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
-            "\"Language: en\\n\"",
+            'msgid ""',
+            'msgstr ""',
+            '"Content-Type: text/plain; charset=UTF-8\\n"',
+            '"Language: en\\n"',
             "",
             // `%%` is an escaped literal percent, not an arg slot; the
             // adjacent `%s` is the only real placeholder (→ {{arg1}}).
-            "msgid \"100%% done with %s\"",
-            "msgstr \"\"",
+            'msgid "100%% done with %s"',
+            'msgstr ""',
             "",
         ].join("\n");
 
@@ -249,20 +259,20 @@ describe("POAdapter", () => {
 
         const output = POAdapter.write(flat, sidecar, "en", "en");
         const reparsed = po.parse(output);
-        expect(
-            reparsed.translations[""]["100%% done with %s"].msgstr[0],
-        ).toBe("100%% done with %s");
+        expect(reparsed.translations[""]["100%% done with %s"].msgstr[0]).toBe(
+            "100%% done with %s",
+        );
     });
 
     it("preserves width / precision specifiers across the round-trip", () => {
         const fixture = [
-            "msgid \"\"",
-            "msgstr \"\"",
-            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
-            "\"Language: en\\n\"",
+            'msgid ""',
+            'msgstr ""',
+            '"Content-Type: text/plain; charset=UTF-8\\n"',
+            '"Language: en\\n"',
             "",
-            "msgid \"%.2f kg at %3d items\"",
-            "msgstr \"\"",
+            'msgid "%.2f kg at %3d items"',
+            'msgstr ""',
             "",
         ].join("\n");
 
@@ -280,13 +290,13 @@ describe("POAdapter", () => {
 
     it("leaves a model-invented arg reference literal instead of dropping it", () => {
         const fixture = [
-            "msgid \"\"",
-            "msgstr \"\"",
-            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
-            "\"Language: en\\n\"",
+            'msgid ""',
+            'msgstr ""',
+            '"Content-Type: text/plain; charset=UTF-8\\n"',
+            '"Language: en\\n"',
             "",
-            "msgid \"Hi %s\"",
-            "msgstr \"\"",
+            'msgid "Hi %s"',
+            'msgstr ""',
             "",
         ].join("\n");
 
@@ -346,14 +356,14 @@ describe("POAdapter", () => {
 describe("POAdapter.readTranslated", () => {
     it("exposes singular msgstr values keyed exactly as read()", () => {
         const target = [
-            "msgid \"\"",
-            "msgstr \"\"",
-            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
-            "\"Language: fr\\n\"",
+            'msgid ""',
+            'msgstr ""',
+            '"Content-Type: text/plain; charset=UTF-8\\n"',
+            '"Language: fr\\n"',
             "",
-            "msgctxt \"menu\"",
-            "msgid \"Save\"",
-            "msgstr \"Enregistrer\"",
+            'msgctxt "menu"',
+            'msgid "Save"',
+            'msgstr "Enregistrer"',
             "",
         ].join("\n");
 
@@ -364,16 +374,16 @@ describe("POAdapter.readTranslated", () => {
 
     it("maps a 2-form target's msgstr[] back onto _one / _other", () => {
         const target = [
-            "msgid \"\"",
-            "msgstr \"\"",
-            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
-            "\"Plural-Forms: nplurals=2; plural=(n > 1);\\n\"",
-            "\"Language: fr\\n\"",
+            'msgid ""',
+            'msgstr ""',
+            '"Content-Type: text/plain; charset=UTF-8\\n"',
+            '"Plural-Forms: nplurals=2; plural=(n > 1);\\n"',
+            '"Language: fr\\n"',
             "",
-            "msgid \"One item\"",
-            "msgid_plural \"%d items\"",
-            "msgstr[0] \"Un élément\"",
-            "msgstr[1] \"%d éléments\"",
+            'msgid "One item"',
+            'msgid_plural "%d items"',
+            'msgstr[0] "Un élément"',
+            'msgstr[1] "%d éléments"',
             "",
         ].join("\n");
 
@@ -386,17 +396,17 @@ describe("POAdapter.readTranslated", () => {
 
     it("collapses a 3-form target onto _one / _other via the source header", () => {
         const target = [
-            "msgid \"\"",
-            "msgstr \"\"",
-            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
-            "\"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\\n\"",
-            "\"Language: pl\\n\"",
+            'msgid ""',
+            'msgstr ""',
+            '"Content-Type: text/plain; charset=UTF-8\\n"',
+            '"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\\n"',
+            '"Language: pl\\n"',
             "",
-            "msgid \"One item\"",
-            "msgid_plural \"%d items\"",
-            "msgstr[0] \"jeden element\"",
-            "msgstr[1] \"%d elementy\"",
-            "msgstr[2] \"%d elementów\"",
+            'msgid "One item"',
+            'msgid_plural "%d items"',
+            'msgstr[0] "jeden element"',
+            'msgstr[1] "%d elementy"',
+            'msgstr[2] "%d elementów"',
             "",
         ].join("\n");
 
@@ -409,16 +419,16 @@ describe("POAdapter.readTranslated", () => {
 
     it("yields empty strings for a target plural with missing msgstr slots", () => {
         const target = [
-            "msgid \"\"",
-            "msgstr \"\"",
-            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
-            "\"Language: fr\\n\"",
+            'msgid ""',
+            'msgstr ""',
+            '"Content-Type: text/plain; charset=UTF-8\\n"',
+            '"Language: fr\\n"',
             "",
             // A half-finished target: msgstr[1] was never filled in.
-            "msgid \"One item\"",
-            "msgid_plural \"%d items\"",
-            "msgstr[0] \"Un élément\"",
-            "msgstr[1] \"\"",
+            'msgid "One item"',
+            'msgid_plural "%d items"',
+            'msgstr[0] "Un élément"',
+            'msgstr[1] ""',
             "",
         ].join("\n");
 
@@ -429,14 +439,14 @@ describe("POAdapter.readTranslated", () => {
 
     it("falls back to 2-form indices when the Language header is missing", () => {
         const target = [
-            "msgid \"\"",
-            "msgstr \"\"",
-            "\"Content-Type: text/plain; charset=UTF-8\\n\"",
+            'msgid ""',
+            'msgstr ""',
+            '"Content-Type: text/plain; charset=UTF-8\\n"',
             "",
-            "msgid \"One item\"",
-            "msgid_plural \"%d items\"",
-            "msgstr[0] \"first\"",
-            "msgstr[1] \"second\"",
+            'msgid "One item"',
+            'msgid_plural "%d items"',
+            'msgstr[0] "first"',
+            'msgstr[1] "second"',
             "",
         ].join("\n");
 
@@ -457,7 +467,7 @@ describe("PropertiesAdapter", () => {
         ].join("\n");
 
         const { flat } = PropertiesAdapter.read(input);
-        expect(flat).toEqual({ "greeting": "Hello", "menu.save": "Save" });
+        expect(flat).toEqual({ greeting: "Hello", "menu.save": "Save" });
     });
 
     it("round-trips a fixture byte-for-byte when nothing changes", () => {
@@ -589,7 +599,12 @@ describe("PropertiesAdapter", () => {
         const input = ["a=one", "b=two"].join("\n");
         const { sidecar } = PropertiesAdapter.read(input);
         // Only `a` is translated; `b` must survive untouched.
-        const output = PropertiesAdapter.write({ a: "un" }, sidecar, "en", "fr");
+        const output = PropertiesAdapter.write(
+            { a: "un" },
+            sidecar,
+            "en",
+            "fr",
+        );
         expect(output).toBe(["a=un", "b=two"].join("\n"));
     });
 
@@ -604,11 +619,11 @@ describe("StringsAdapter", () => {
     it("reads quoted key/value pairs and ignores comments", () => {
         const input =
             "/* Greeting */\n" +
-            "\"greeting\" = \"Hello\";\n" +
-            "\"menu.save\" = \"Save\";\n";
+            '"greeting" = "Hello";\n' +
+            '"menu.save" = "Save";\n';
 
         const { flat } = StringsAdapter.read(input);
-        expect(flat).toEqual({ "greeting": "Hello", "menu.save": "Save" });
+        expect(flat).toEqual({ greeting: "Hello", "menu.save": "Save" });
     });
 
     it("round-trips a fixture with comments and blanks byte-for-byte", () => {
@@ -626,15 +641,13 @@ describe("StringsAdapter", () => {
     });
 
     it("normalizes %@ and %d placeholders to {{argN}}", () => {
-        const { flat } = StringsAdapter.read(
-            "\"k\" = \"Hi %@, you have %d new\";",
-        );
+        const { flat } = StringsAdapter.read('"k" = "Hi %@, you have %d new";');
 
         expect(flat.k).toBe("Hi {{arg1}}, you have {{arg2}} new");
     });
 
     it("restores positional placeholders on a changed value", () => {
-        const input = "\"k\" = \"%1$@ sent %2$@\";";
+        const input = '"k" = "%1$@ sent %2$@";';
         const { flat, sidecar } = StringsAdapter.read(input);
         expect(flat.k).toBe("{{arg1}} sent {{arg2}}");
 
@@ -645,31 +658,31 @@ describe("StringsAdapter", () => {
             "fr",
         );
 
-        expect(output).toBe("\"k\" = \"%2$@ reçu de %1$@\";");
+        expect(output).toBe('"k" = "%2$@ reçu de %1$@";');
     });
 
     it("leaves a %% literal intact while normalizing a real %@", () => {
-        const { flat } = StringsAdapter.read("\"k\" = \"100%% sure %@\";");
+        const { flat } = StringsAdapter.read('"k" = "100%% sure %@";');
         expect(flat.k).toBe("100%% sure {{arg1}}");
     });
 
     it("decodes escapes and round-trips them byte-for-byte", () => {
-        const input = "\"k\" = \"Line1\\nQuote: \\\"hi\\\" \\\\ end\";";
+        const input = '"k" = "Line1\\nQuote: \\"hi\\" \\\\ end";';
         const { flat, sidecar } = StringsAdapter.read(input);
-        expect(flat.k).toBe("Line1\nQuote: \"hi\" \\ end");
+        expect(flat.k).toBe('Line1\nQuote: "hi" \\ end');
         expect(StringsAdapter.write(flat, sidecar, "en", "en")).toBe(input);
     });
 
     it("decodes \\Uxxxx escapes into their characters", () => {
-        const { flat } = StringsAdapter.read("\"k\" = \"caf\\U00e9\";");
+        const { flat } = StringsAdapter.read('"k" = "caf\\U00e9";');
         expect(flat.k).toBe("café");
     });
 
     it("round-trips \\t and \\r escapes both ways", () => {
-        const { flat } = StringsAdapter.read("\"k\" = \"a\\tb\\rc\";");
+        const { flat } = StringsAdapter.read('"k" = "a\\tb\\rc";');
         expect(flat.k).toBe("a\tb\rc");
 
-        const { sidecar } = StringsAdapter.read("\"k\" = \"v\";");
+        const { sidecar } = StringsAdapter.read('"k" = "v";');
         const output = StringsAdapter.write(
             { k: "a\tb\rc\\d" },
             sidecar,
@@ -677,37 +690,37 @@ describe("StringsAdapter", () => {
             "fr",
         );
 
-        expect(output).toBe("\"k\" = \"a\\tb\\rc\\\\d\";");
+        expect(output).toBe('"k" = "a\\tb\\rc\\\\d";');
     });
 
     it("re-escapes quotes, newlines, and backslashes for changed values", () => {
-        const { sidecar } = StringsAdapter.read("\"k\" = \"v\";");
+        const { sidecar } = StringsAdapter.read('"k" = "v";');
         const output = StringsAdapter.write(
-            { k: "say \"hi\"\nbye" },
+            { k: 'say "hi"\nbye' },
             sidecar,
             "en",
             "fr",
         );
 
-        expect(output).toBe("\"k\" = \"say \\\"hi\\\"\\nbye\";");
+        expect(output).toBe('"k" = "say \\"hi\\"\\nbye";');
     });
 
     it("keeps = and ; that appear inside a value", () => {
-        const input = "\"k\" = \"a=b; c\";";
+        const input = '"k" = "a=b; c";';
         const { flat, sidecar } = StringsAdapter.read(input);
         expect(flat.k).toBe("a=b; c");
         expect(StringsAdapter.write(flat, sidecar, "en", "en")).toBe(input);
     });
 
     it("re-emits the original value for keys missing from the translation", () => {
-        const input = "\"a\" = \"one\";\n\"b\" = \"two\";";
+        const input = '"a" = "one";\n"b" = "two";';
         const { sidecar } = StringsAdapter.read(input);
         const output = StringsAdapter.write({ a: "un" }, sidecar, "en", "fr");
-        expect(output).toBe("\"a\" = \"un\";\n\"b\" = \"two\";");
+        expect(output).toBe('"a" = "un";\n"b" = "two";');
     });
 
     it("leaves a model-invented placeholder literal on write", () => {
-        const { sidecar } = StringsAdapter.read("\"k\" = \"Value %@\";");
+        const { sidecar } = StringsAdapter.read('"k" = "Value %@";');
         const output = StringsAdapter.write(
             { k: "{{arg1}} et {{arg9}}" },
             sidecar,
@@ -715,11 +728,11 @@ describe("StringsAdapter", () => {
             "fr",
         );
 
-        expect(output).toBe("\"k\" = \"%@ et {{arg9}}\";");
+        expect(output).toBe('"k" = "%@ et {{arg9}}";');
     });
 
     it("preserves a block comment and a file with no trailing newline", () => {
-        const input = "/* c */\n\"k\" = \"v\";";
+        const input = '/* c */\n"k" = "v";';
         const { flat, sidecar } = StringsAdapter.read(input);
         expect(StringsAdapter.write(flat, sidecar, "en", "en")).toBe(input);
     });
@@ -731,7 +744,7 @@ const YAML_FIXTURE = [
     "  greeting: Hello",
     "  inbox:",
     "    # how many unread",
-    "    unread: \"You have %{count} messages\"",
+    '    unread: "You have %{count} messages"',
     "    price: '%<amount>.2f owing'",
     "  day_names:",
     "    - Monday",
@@ -901,15 +914,15 @@ describe("YAMLAdapter", () => {
 });
 
 const TS_FIXTURE = [
-    "import type { Translations } from \"./types\";",
+    'import type { Translations } from "./types";',
     "",
     "// Locale catalogue",
     "export const enTranslations = {",
     "    TimeSignatureModal: {",
-    "        header: \"Time Signature\",",
+    '        header: "Time Signature",',
     "        hint: 'Pick a value',",
     "    },",
-    "    counts: [\"one\", \"two\"],",
+    '    counts: ["one", "two"],',
     "    total: 3,",
     "    dynamic: `${1} items`,",
     "} satisfies Translations;",
@@ -951,7 +964,7 @@ describe("module adapter (.ts / .js)", () => {
         expect(output).toContain("import type { Translations }");
         expect(output).toContain("// Locale catalogue");
         expect(output).toContain("satisfies Translations");
-        expect(output).toContain("header: \"Signature rythmique\"");
+        expect(output).toContain('header: "Signature rythmique"');
         // The single-quoted entry stays single-quoted.
         expect(output).toContain("hint: 'Choisissez une valeur'");
         // Untouched non-literals survive verbatim.
@@ -964,7 +977,7 @@ describe("module adapter (.ts / .js)", () => {
         const output = TypeScriptAdapter.write(
             {
                 ...flat,
-                "TimeSignatureModal*header": "L\"un\"\nsuite\\fin",
+                "TimeSignatureModal*header": 'L"un"\nsuite\\fin',
                 "TimeSignatureModal*hint": "L'un",
             },
             sidecar,
@@ -972,16 +985,16 @@ describe("module adapter (.ts / .js)", () => {
             "fr",
         );
 
-        expect(output).toContain("header: \"L\\\"un\\\"\\nsuite\\\\fin\"");
+        expect(output).toContain('header: "L\\"un\\"\\nsuite\\\\fin"');
         expect(output).toContain("hint: 'L\\'un'");
         // The re-parsed file yields exactly what we put in.
         const { flat: reread } = TypeScriptAdapter.read(output);
-        expect(reread["TimeSignatureModal*header"]).toBe("L\"un\"\nsuite\\fin");
+        expect(reread["TimeSignatureModal*header"]).toBe('L"un"\nsuite\\fin');
         expect(reread["TimeSignatureModal*hint"]).toBe("L'un");
     });
 
     it("finds a CommonJS module.exports catalogue", () => {
-        const input = "module.exports = { greeting: \"Hello\" };\n";
+        const input = 'module.exports = { greeting: "Hello" };\n';
         const { flat, sidecar } = JavaScriptAdapter.read(input);
 
         expect(flat).toEqual({ greeting: "Hello" });
@@ -992,13 +1005,13 @@ describe("module adapter (.ts / .js)", () => {
                 "en",
                 "fr",
             ),
-        ).toBe("module.exports = { greeting: \"Bonjour\" };\n");
+        ).toBe('module.exports = { greeting: "Bonjour" };\n');
     });
 
     it("prefers a default export over other object literals", () => {
         const input = [
-            "const helper = { ignored: \"nope\" };",
-            "export default { greeting: \"Hello\" };",
+            'const helper = { ignored: "nope" };',
+            'export default { greeting: "Hello" };',
             "",
         ].join("\n");
 
@@ -1008,14 +1021,14 @@ describe("module adapter (.ts / .js)", () => {
     });
 
     it("handles `export default {...} as const`", () => {
-        const input = "export default { greeting: \"Hello\" } as const;\n";
+        const input = 'export default { greeting: "Hello" } as const;\n';
         expect(TypeScriptAdapter.read(input).flat).toEqual({
             greeting: "Hello",
         });
     });
 
     it("reads quoted and dotted keys", () => {
-        const input = "export default { \"foo.bar\": \"x\", 'a b': \"y\" };\n";
+        const input = 'export default { "foo.bar": "x", \'a b\': "y" };\n';
         expect(TypeScriptAdapter.read(input).flat).toEqual({
             "a b": "y",
             "foo.bar": "x",
@@ -1023,7 +1036,7 @@ describe("module adapter (.ts / .js)", () => {
     });
 
     it("falls back to a lone bare const", () => {
-        const input = "const translations = { greeting: \"Hello\" };\n";
+        const input = 'const translations = { greeting: "Hello" };\n';
         expect(TypeScriptAdapter.read(input).flat).toEqual({
             greeting: "Hello",
         });
@@ -1031,8 +1044,8 @@ describe("module adapter (.ts / .js)", () => {
 
     it("skips computed keys and spreads it cannot address", () => {
         const input = [
-            "const base = { a: \"A\" };",
-            "export default { ...base, [key]: \"skipped\", kept: \"Kept\" };",
+            'const base = { a: "A" };',
+            'export default { ...base, [key]: "skipped", kept: "Kept" };',
             "",
         ].join("\n");
 
@@ -1056,5 +1069,267 @@ describe("module adapter (.ts / .js)", () => {
         expect(() =>
             TypeScriptAdapter.read("export function f() {}\n"),
         ).toThrow(/No translation object found/);
+    });
+});
+
+const ICU_FIXTURE = `${JSON.stringify(
+    {
+        HomePage: {
+            items: "You have {count, plural, one {# item} other {# items}} left",
+            price: "Costs {amount, number, ::currency/USD}",
+            rich: "Read <link>the docs</link>",
+            title: "Hello {name}!",
+            who: "{gender, select, male {He} female {She} other {They}} replied",
+        },
+        retries: 3,
+    },
+    null,
+    4,
+)}\n`;
+
+describe("ICUAdapter", () => {
+    it("normalizes ICU arguments into the pipeline's placeholder convention", () => {
+        const { flat } = ICUAdapter.read(ICU_FIXTURE);
+        expect(flat["HomePage*title"]).toBe("Hello {{name}}!");
+        expect(flat["HomePage*price"]).toBe("Costs {{amount}}");
+    });
+
+    it("keeps rich-text tags inline so the sentence stays readable", () => {
+        const { flat } = ICUAdapter.read(ICU_FIXTURE);
+        expect(flat["HomePage*rich"]).toBe("Read <link>the docs</link>");
+    });
+
+    it("expands a plural into whole sentences, not fragments", () => {
+        const { flat } = ICUAdapter.read(ICU_FIXTURE);
+        // The literals around the plural are repeated into each branch so
+        // the model translates a full sentence and target languages can
+        // reorder words per plural form.
+        expect(flat["HomePage*items_one"]).toBe("You have {{#}} item left");
+        expect(flat["HomePage*items_other"]).toBe("You have {{#}} items left");
+        expect(flat["HomePage*items"]).toBeUndefined();
+    });
+
+    it("expands select branches under a distinct suffix", () => {
+        const { flat } = ICUAdapter.read(ICU_FIXTURE);
+        expect(flat["HomePage*who_select_male"]).toBe("He replied");
+        expect(flat["HomePage*who_select_female"]).toBe("She replied");
+        expect(flat["HomePage*who_select_other"]).toBe("They replied");
+    });
+
+    it("does not offer non-string values for translation", () => {
+        const { flat } = ICUAdapter.read(ICU_FIXTURE);
+        expect(flat.retries).toBeUndefined();
+    });
+
+    it("round-trips an untouched catalogue byte-for-byte", () => {
+        const { flat, sidecar } = ICUAdapter.read(ICU_FIXTURE);
+        expect(ICUAdapter.write(flat, sidecar, "en", "en")).toBe(ICU_FIXTURE);
+    });
+
+    it("preserves a number skeleton exactly", () => {
+        const { flat, sidecar } = ICUAdapter.read(ICU_FIXTURE);
+        const out = JSON.parse(
+            ICUAdapter.write(
+                { ...flat, "HomePage*price": "Coûte {{amount}}" },
+                sidecar,
+                "en",
+                "fr",
+            ),
+        );
+        expect(out.HomePage.price).toBe(
+            "Coûte {amount, number, ::currency/USD}",
+        );
+    });
+
+    it("rebuilds a plural with the target language's categories", () => {
+        const { flat, sidecar } = ICUAdapter.read(ICU_FIXTURE);
+        const translated = {
+            ...flat,
+            "HomePage*items_one": "Il reste {{#}} article",
+            "HomePage*items_other": "Il reste {{#}} articles",
+        };
+
+        const fr = JSON.parse(
+            ICUAdapter.write(translated, sidecar, "en", "fr"),
+        );
+        expect(fr.HomePage.items).toBe(
+            "{count, plural, one {Il reste # article} other {Il reste # articles}}",
+        );
+    });
+
+    it("emits an `other` branch even when the plural table omits it", () => {
+        // Gettext's table is index-based and gives Russian one/few/many.
+        // ICU *requires* `other`; without it the message is invalid and
+        // would be silently rejected, leaving the entry untranslated.
+        const { flat, sidecar } = ICUAdapter.read(ICU_FIXTURE);
+        const translated = {
+            ...flat,
+            "HomePage*items_one": "one-form",
+            "HomePage*items_other": "other-form",
+        };
+
+        const ru = JSON.parse(
+            ICUAdapter.write(translated, sidecar, "en", "ru"),
+        );
+        expect(ru.HomePage.items).toContain("one {one-form}");
+        expect(ru.HomePage.items).toContain("few {other-form}");
+        expect(ru.HomePage.items).toContain("many {other-form}");
+        expect(ru.HomePage.items).toContain("other {other-form}");
+    });
+
+    it("collapses to a single branch for languages without plurals", () => {
+        const { flat, sidecar } = ICUAdapter.read(ICU_FIXTURE);
+        const translated = {
+            ...flat,
+            "HomePage*items_one": "one-form",
+            "HomePage*items_other": "other-form",
+        };
+
+        const ja = JSON.parse(
+            ICUAdapter.write(translated, sidecar, "en", "ja"),
+        );
+        expect(ja.HomePage.items).toBe("{count, plural, other {other-form}}");
+    });
+
+    it("rebuilds a select with its original categories", () => {
+        const { flat, sidecar } = ICUAdapter.read(ICU_FIXTURE);
+        const translated = {
+            ...flat,
+            "HomePage*who_select_female": "Elle a répondu",
+            "HomePage*who_select_male": "Il a répondu",
+            "HomePage*who_select_other": "Iel a répondu",
+        };
+
+        const fr = JSON.parse(
+            ICUAdapter.write(translated, sidecar, "en", "fr"),
+        );
+        expect(fr.HomePage.who).toBe(
+            "{gender, select, male {Il a répondu} female {Elle a répondu} other {Iel a répondu}}",
+        );
+    });
+
+    it("keeps the source when a translation would produce invalid ICU", () => {
+        const { flat, sidecar } = ICUAdapter.read(ICU_FIXTURE);
+        const out = JSON.parse(
+            ICUAdapter.write(
+                { ...flat, "HomePage*title": "Bonjour {name!" },
+                sidecar,
+                "en",
+                "fr",
+            ),
+        );
+        // Better an untranslated string than a catalogue that throws at
+        // runtime in the user's app.
+        expect(out.HomePage.title).toBe("Hello {name}!");
+    });
+
+    it("passes through messages too complex to split safely", () => {
+        const nested = `${JSON.stringify(
+            {
+                hard: "{a, plural, one {{b, plural, one {x} other {y}}} other {z}}",
+            },
+            null,
+            4,
+        )}\n`;
+
+        const { flat, sidecar } = ICUAdapter.read(nested);
+        expect(Object.keys(flat)).toHaveLength(0);
+        expect(ICUAdapter.write(flat, sidecar, "en", "fr")).toBe(nested);
+    });
+
+    it("treats a non-ICU string as plain text", () => {
+        const raw = `${JSON.stringify({ odd: "100% done" }, null, 4)}\n`;
+        const { flat, sidecar } = ICUAdapter.read(raw);
+        expect(flat.odd).toBe("100% done");
+        expect(ICUAdapter.write(flat, sidecar, "en", "en")).toBe(raw);
+    });
+
+    it("preserves a plural offset and selectordinal", () => {
+        const raw = `${JSON.stringify(
+            {
+                ordinal: "{n, selectordinal, one {#st} other {#th}}",
+                withOffset:
+                    "{n, plural, offset:1 one {# other} other {# others}}",
+            },
+            null,
+            4,
+        )}\n`;
+
+        const { flat, sidecar } = ICUAdapter.read(raw);
+        const out = JSON.parse(
+            ICUAdapter.write(
+                {
+                    ...flat,
+                    ordinal_one: "#er",
+                    ordinal_other: "#e",
+                    withOffset_one: "{{#}} autre",
+                    withOffset_other: "{{#}} autres",
+                },
+                sidecar,
+                "en",
+                "fr",
+            ),
+        );
+        expect(out.withOffset).toContain("offset:1");
+        expect(out.ordinal).toContain("selectordinal");
+    });
+
+    it("carries exact `=0` matches across languages", () => {
+        const raw = `${JSON.stringify(
+            { n: "{c, plural, =0 {none} one {# item} other {# items}}" },
+            null,
+            4,
+        )}\n`;
+
+        const { flat, sidecar } = ICUAdapter.read(raw);
+        expect(flat["n_=0"]).toBe("none");
+
+        const out = JSON.parse(
+            ICUAdapter.write(
+                {
+                    ...flat,
+                    "n_=0": "aucun",
+                    n_one: "{{#}} article",
+                    n_other: "{{#}} articles",
+                },
+                sidecar,
+                "en",
+                "ru",
+            ),
+        );
+        // `=0` is a literal match, not a CLDR category: it survives even
+        // though Russian's category list never mentions it.
+        expect(out.n).toContain("=0 {aucun}");
+        expect(out.n).toContain("many {");
+    });
+
+    it("keeps the source when only some select branches were translated", () => {
+        const { flat, sidecar } = ICUAdapter.read(ICU_FIXTURE);
+        const partial = { ...flat };
+        delete partial["HomePage*who_select_other"];
+        partial["HomePage*who_select_male"] = "Il a r\u00e9pondu";
+
+        const out = JSON.parse(ICUAdapter.write(partial, sidecar, "en", "fr"));
+        expect(out.HomePage.who).toBe(
+            "{gender, select, male {He} female {She} other {They}} replied",
+        );
+    });
+
+    it("does not mutate the sidecar between target languages", () => {
+        const { flat, sidecar } = ICUAdapter.read(ICU_FIXTURE);
+        const translated = {
+            ...flat,
+            "HomePage*items_one": "one-form",
+            "HomePage*items_other": "other-form",
+        };
+
+        const first = ICUAdapter.write(translated, sidecar, "en", "ru");
+        const second = ICUAdapter.write(translated, sidecar, "en", "ru");
+        expect(second).toBe(first);
+        // And a different language still starts from the same source.
+        expect(
+            JSON.parse(ICUAdapter.write(translated, sidecar, "en", "ja"))
+                .HomePage.items,
+        ).toBe("{count, plural, other {other-form}}");
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -820,6 +820,13 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@messageformat/parser@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@messageformat/parser/-/parser-5.1.1.tgz#ca7d6c18e9f3f6b6bc984a465dac16da00106055"
+  integrity sha512-3p0YRGCcTUCYvBKLIxtDDyrJ0YijGIwrTRu1DT8gIviIDZru8H23+FkY6MJBzM1n9n20CiM4VeDYuBsrrwnLjg==
+  dependencies:
+    moo "^0.5.1"
+
 "@microsoft/tsdoc-config@0.17.1":
   version "0.17.1"
   resolved "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.17.1.tgz"
@@ -3964,6 +3971,11 @@ minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
+moo@^0.5.1:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.3.tgz#dfcdb40ff6f1a03c34af5df7f9717cecfa88c38c"
+  integrity sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==
+
 ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
@@ -4674,16 +4686,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5214,16 +5217,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
next-intl is the largest i18n runtime we could not serve — ~5M weekly downloads, and the default for the Next.js App Router. Its messages are ICU MessageFormat, which the JSON adapter treats as opaque strings, so plurals and arguments went to the model raw.

**Opt-in by design.** Registered by name only, with no extensions, so `.json` keeps resolving to the i18next adapter and existing users are untouched. Enable with `--file-format icu`.

### How messages are handled

Arguments become `{{var}}` so the prompts' existing placeholder protection applies, and the original source is restored verbatim on write — reconstructing a skeleton like `::currency/USD` from parsed parts is easy to get subtly wrong. Rich-text tags stay inline as literal text.

Plural and select messages expand into one **whole sentence per branch** rather than fragments:

```
"You have {count, plural, one {# item} other {# items}} left"
  -> "You have {{#}} item left"
  -> "You have {{#}} items left"
```

The model gets full context instead of disconnected fragments, and a target language can order words differently in each plural form. On write the branches are re-assembled against the **target** language's CLDR categories, so an English `one`/`other` source yields `one`/`few`/`many`/`other` for Russian, and collapses to `other` alone for Japanese. Exact matches like `=0` carry across untouched.

### Two findings worth flagging

**ICU requires an `other` branch**, but `po_plural_rules` is index-based and omits it for languages like Russian (`one`/`few`/`many`). Reusing that table directly produced *invalid ICU*, which the validity check then rejected — silently leaving those entries untranslated. Caught it because a Russian round-trip returned untranslated English. Target categories are now unioned with `other`.

**The obvious parser is ESM-only.** `@formatjs/icu-messageformat-parser` is `"type": "module"` with no CommonJS build. It appeared to work in my first pass only because Node 22.12+ supports `require(esm)` — on Node 18 or 20 it throws at import time. Since `registry.ts` loads every adapter eagerly, that would have broken the library **for users who never touch ICU**. Switched to `@messageformat/parser`, which is CommonJS.

### Safety

- A rebuilt message that fails to re-parse is discarded in favour of the original, so a bad translation can never emit a catalogue that throws in the user's app
- Messages with nested or multiple plural/select blocks are passed through **untranslated** rather than mangled
- Untouched entries round-trip byte-for-byte
- Non-string JSON values and non-ICU strings are preserved

### Known limitation

Categories the source doesn't supply are filled from `other` — structurally valid but not correctly inflected. This is the same approximation `po_adapter` already makes, so I matched it rather than inventing different behaviour; it is documented in the guide as needing review. Doing better requires letting an adapter request keys the source doesn't have, which is a pipeline change I would rather propose separately.

### Testing

18 new tests, 87% line coverage on the adapter: argument normalization, skeleton preservation, tags, plural/select expansion, per-language re-assembly (fr/ru/ja), `=0` exact matches, offset and `selectordinal`, invalid-ICU fallback, nested passthrough, sidecar reuse across languages, and byte-for-byte round-trip. Full suite 275 passing, lint clean, and I verified a realistic next-intl file end-to-end through the built registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)