### PR TITLE
chore: release 5.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "zod-to-json-schema": "^3.24.1"
   },
   "name": "i18n-ai-translate",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "files": [
     "build",
     "!build/test",


### PR DESCRIPTION
Bumps `5.2.0` → `5.3.0`. Only `package.json` changes — `VERSION` in `constants.ts` imports it.

**Minor, not patch.** ICU MessageFormat / next-intl support (#503) is new backward-compatible functionality and adds a runtime dependency (`@messageformat/parser`). A patch number would misrepresent that to anyone pinned to a `~5.2.x` range.

### Since 5.2.0

- **ICU MessageFormat / next-intl adapter** (#503) — opt-in via `--file-format icu`, so `.json` still resolves to the i18next adapter
- `action.yml` description trimmed under the Marketplace 125-char limit (#502)
- Trusted publishing workflow (#501)

### First release through trusted publishing

After merging, `git tag v5.3.0 && git push origin v5.3.0` triggers the release workflow, which publishes with **no token**. If the Trusted Publisher config on npmjs.com does not match, the publish fails with a 404 and nothing is released — so the downside of it not working is a failed job, not a bad publish.

### Verification

- Full clean rebuild from scratch (`rm -rf build tsconfig.tsbuildinfo`), 275 tests passing, lint clean
- CLI bundle still **7.6 MB** — the ICU parser and its single dependency add nothing measurable
- Ran the release workflow's own guard scripts against this tree: tag `v5.3.0` matches, `5.3.0` is unpublished, and a mistaken `v5.2.1` tag is correctly rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)