### PR TITLE
fix(ci): let yarn install under trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,15 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+        env:
+          # setup-node's registry-url writes an .npmrc containing
+          # `_authToken=${NODE_AUTH_TOKEN}`. Yarn 1 expands env vars in
+          # .npmrc eagerly and errors when the variable is undefined --
+          # and with trusted publishing there is deliberately no token.
+          # Defining it empty satisfies the substitution; an empty token
+          # is falsy, so yarn sends no auth header and installs public
+          # packages normally.
+          NODE_AUTH_TOKEN: ""
 
       - name: Run lint
         run: npm run lint


### PR DESCRIPTION
The first trusted-publishing run ([31873908460](https://github.com/taahamahdi/i18n-ai-translate/actions/runs/31873908460)) failed three steps before publish:

```
error Failed to replace env in config: ${NODE_AUTH_TOKEN}
```

`setup-node`'s `registry-url` writes an `.npmrc` containing `_authToken=${NODE_AUTH_TOKEN}` and points `NPM_CONFIG_USERCONFIG` at it. **Yarn 1 expands env vars in `.npmrc` eagerly and errors when the variable is undefined** — and with trusted publishing there is deliberately no token to define. npm tolerates the identical file, which is why this only shows up on the yarn step.

Defining `NODE_AUTH_TOKEN` as empty for that one step satisfies yarn's substitution. An empty token is falsy, so yarn sends no auth header and installs public packages normally, and the publish step still uses the config `setup-node` generated.

**Nothing was published.** The failure was at dependency install, so the version guards never ran and no release was cut. Checkout, the Node setup, and the npm upgrade all succeeded — but trusted publishing itself is still unproven, since the run never reached it.

No new tag needed to retry: `workflow_dispatch` is already wired up, and the tag-match guard is conditioned on `push` events, so this can be re-run manually against master. The "already published" guard still applies, so 5.3.0 cannot be double-published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)