### PR TITLE
docs: bring the GitHub Action docs in line with action.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,5 +16,5 @@ jobs:
       - name: Test i18n-ai-translate action
         uses: taahamahdi/i18n-ai-translate@master
         with:
-          json-file-path: test/en.json
+          file-path: test/en.json
           api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/ADVANCED_GUIDE.md
+++ b/ADVANCED_GUIDE.md
@@ -91,6 +91,12 @@ on:
         paths:
             - "i18n/en.json"
 
+# The Action commits the new translations back to the PR branch, so the
+# job needs write access to repository contents. Repositories whose
+# default GITHUB_TOKEN is read-only will otherwise fail at the push.
+permissions:
+    contents: write
+
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -98,9 +104,34 @@ jobs:
             - name: i18n-ai-translate
               uses: taahamahdi/i18n-ai-translate@master
               with:
-                  json-file-path: i18n/en.json
+                  file-path: i18n/en.json
                   api-key: ${{ secrets.OPENAI_API_KEY }}
 ```
+
+#### Inputs
+
+| Input | Default | Description |
+|---|---|---|
+| `file-path` | — | Source i18n file. Any supported format, not just JSON |
+| `api-key` | — | Provider API key; passed to the CLI through the engine's environment variable rather than the command line |
+| `host` | — | Ollama host and port, as an alternative to `api-key` |
+| `version` | `latest` | Which published version to run. Pin it for reproducible CI |
+| `language` | `en` | Language to translate from |
+| `engine` | `chatgpt` | `chatgpt`, `gemini`, `claude`, or `ollama` |
+| `model` | `gpt-5.2` | Model to use |
+| `file-format` | from extension | Override format detection |
+| `context` | — | Product/domain context, forwarded to `--context` |
+| `glossary` | — | Path to a glossary JSON file |
+| `batch-size` | `32` | Keys per request |
+| `templated-string-prefix` | `{{` | Opening placeholder delimiter |
+| `templated-string-suffix` | `}}` | Closing placeholder delimiter |
+| `node-version` | `22` | Node version used to run the CLI |
+| `commit-message` | `Update translations` | Message for the translation commit |
+| `author-name` / `author-email` | maintainer defaults | Attribution for the commit |
+
+`json-file-path` is the former name of `file-path`. It still works and emits a deprecation warning, since the Action handles more than JSON now.
+
+If neither `api-key` nor `host` is set, the Action logs a warning, restores the source file, and exits without committing — so an unconfigured secret produces a no-op rather than a failed job.
 
 ### Running directly
 

--- a/README.md
+++ b/README.md
@@ -101,9 +101,13 @@ Runs the verification pipeline against your existing translations without writin
 Add a one-liner GitHub Action to auto-translate whenever `en.json` changes:
 
 ```yaml
+permissions:
+  contents: write   # the Action commits translations back to the PR
+
+# ...
 - uses: taahamahdi/i18n-ai-translate@master
   with:
-    json-file-path: i18n/en.json
+    file-path: i18n/en.json
     api-key: ${{ secrets.OPENAI_API_KEY }}
 ```
 


### PR DESCRIPTION
#499 reworked the Action but left its documentation describing the old shape. Both the guide and the README still showed `json-file-path` — now the deprecated alias — and none of the inputs added in that PR were documented anywhere.

### Changes

- **Documents all 17 inputs**, including `version` (pin a release instead of resolving `@latest` every run), `file-format`, `context`, `glossary`, `node-version`, and `commit-message`.
- **`json-file-path` → `file-path`** in both examples, with a note that the old name still works and warns.
- **Adds `permissions: contents: write`** to the example workflows. The Action commits translations back to the PR branch, and repositories whose default `GITHUB_TOKEN` is read-only fail at the push. This was never documented — anyone copying the old snippet into a repo with default-read-only tokens hits a confusing failure at the very last step.
- Notes that a missing `api-key`/`host` is a **no-op**, not a failed job.
- Updates the repo's own `test.yml` to the non-deprecated input, so CI exercises the current path rather than the back-compat one.

### Verification

Checked every input name in the table against `action.yml` programmatically rather than by eye, which caught that my first draft compressed `templated-string-suffix` into a `prefix / -suffix` shorthand — it would not have matched a reader searching for the literal input name. Both files' code fences still balance, and both YAML files still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)